### PR TITLE
도메인 설계

### DIFF
--- a/src/main/java/welkit_server/domain/community/entity/CommunityComments.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityComments.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Table(name="community_comments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class CommunityComments {
+public class CommunityComments extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/community/entity/CommunityComments.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityComments.java
@@ -1,0 +1,48 @@
+package welkit_server.domain.community.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import welkit_server.domain.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@Table(name="community_comments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommunityComments {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private CommunityPosts post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private CommunityComments parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CommunityComments> children = new ArrayList<>();
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/welkit_server/domain/community/entity/CommunityFeedBack.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityFeedBack.java
@@ -1,0 +1,41 @@
+package welkit_server.domain.community.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import welkit_server.domain.community.model.TargetType;
+import welkit_server.domain.user.entity.User;
+
+@Entity
+@Getter
+@Builder
+@Table(name="community_feedbacks",
+        uniqueConstraints = {
+        @UniqueConstraint(
+                columnNames = {"target_type", "target_id", "user_id"}
+        )
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommunityFeedBack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TargetType targetType;
+
+    @Column(nullable = false)
+    private Long targetId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "is_helpful")
+    private Boolean isHelpful;
+
+}
+

--- a/src/main/java/welkit_server/domain/community/entity/CommunityFeedBack.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityFeedBack.java
@@ -17,7 +17,7 @@ import welkit_server.domain.user.entity.User;
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class CommunityFeedBack {
+public class CommunityFeedBack extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/community/entity/CommunityPosts.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityPosts.java
@@ -1,0 +1,34 @@
+package welkit_server.domain.community.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import welkit_server.domain.community.model.CommunityPostStatus;
+import welkit_server.domain.user.entity.User;
+
+@Entity
+@Getter
+@Builder
+@Table(name="community_posts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommunityPosts {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable=false, length = 50)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private CommunityPostStatus status;
+
+}

--- a/src/main/java/welkit_server/domain/community/entity/CommunityPosts.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityPosts.java
@@ -11,7 +11,7 @@ import welkit_server.domain.user.entity.User;
 @Table(name="community_posts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class CommunityPosts {
+public class CommunityPosts extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/community/model/CommunityPostStatus.java
+++ b/src/main/java/welkit_server/domain/community/model/CommunityPostStatus.java
@@ -1,0 +1,7 @@
+package welkit_server.domain.community.model;
+
+public enum CommunityPostStatus {
+    NORMAL,        // 정상
+    UNDER_REVIEW,  // 제재대상
+    BANNED         // 제재완료
+}

--- a/src/main/java/welkit_server/domain/community/model/TargetType.java
+++ b/src/main/java/welkit_server/domain/community/model/TargetType.java
@@ -1,0 +1,6 @@
+package welkit_server.domain.community.model;
+
+public enum TargetType {
+    POSTS,
+    COMMENTS
+}

--- a/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
+++ b/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Table(name="insight_cards")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class InsightCard {
+public class InsightCard extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
+++ b/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
@@ -1,0 +1,49 @@
+package welkit_server.domain.insightcard.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import welkit_server.domain.insightcard.model.CardType;
+import welkit_server.domain.user.entity.User;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@Table(name="insight_cards")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class InsightCard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(columnDefinition = "TEXT")
+    private String note;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false,length = 25)
+    private CardType cardType;
+
+    @Column(name = "is_favorite", nullable = false)
+    @Builder.Default
+    private boolean isFavorite = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "last_viewed_at", nullable = false)
+    private LocalDateTime lastViewedAt;
+
+    public void updateLastViewedAt() {
+        this.lastViewedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/welkit_server/domain/insightcard/model/CardType.java
+++ b/src/main/java/welkit_server/domain/insightcard/model/CardType.java
@@ -1,0 +1,6 @@
+package welkit_server.domain.insightcard.model;
+
+public enum CardType {
+    PERSON,
+    WORK
+}

--- a/src/main/java/welkit_server/domain/mypage/entity/Notice.java
+++ b/src/main/java/welkit_server/domain/mypage/entity/Notice.java
@@ -1,0 +1,29 @@
+package welkit_server.domain.mypage.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import welkit_server.domain.mypage.model.NoticePriority;
+
+@Entity
+@Getter
+@Builder
+@Table(name="notices")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 25)
+    private NoticePriority priority;
+
+}

--- a/src/main/java/welkit_server/domain/mypage/entity/Notice.java
+++ b/src/main/java/welkit_server/domain/mypage/entity/Notice.java
@@ -10,7 +10,7 @@ import welkit_server.domain.mypage.model.NoticePriority;
 @Table(name="notices")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Notice {
+public class Notice extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/mypage/model/NoticePriority.java
+++ b/src/main/java/welkit_server/domain/mypage/model/NoticePriority.java
@@ -1,0 +1,7 @@
+package welkit_server.domain.mypage.model;
+
+public enum NoticePriority {
+    LOW,
+    MEDIUM,
+    HIGH
+}

--- a/src/main/java/welkit_server/domain/retrospectives/entity/Retrospective.java
+++ b/src/main/java/welkit_server/domain/retrospectives/entity/Retrospective.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 @Table(name="retrospectives")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Retrospective {
+public class Retrospective extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/retrospectives/entity/Retrospective.java
+++ b/src/main/java/welkit_server/domain/retrospectives/entity/Retrospective.java
@@ -1,0 +1,41 @@
+package welkit_server.domain.retrospectives.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import welkit_server.domain.retrospectives.model.Type;
+import welkit_server.domain.user.entity.User;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder
+@Table(name="retrospectives")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Retrospective {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 25)
+    private Type type;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+}

--- a/src/main/java/welkit_server/domain/retrospectives/model/Type.java
+++ b/src/main/java/welkit_server/domain/retrospectives/model/Type.java
@@ -1,0 +1,6 @@
+package welkit_server.domain.retrospectives.model;
+
+public enum Type {
+    WEEKLY,
+    MONTHLY
+}

--- a/src/main/java/welkit_server/domain/terms/entity/Term.java
+++ b/src/main/java/welkit_server/domain/terms/entity/Term.java
@@ -7,13 +7,7 @@ import welkit_server.domain.user.entity.User;
 @Entity
 @Getter
 @Builder
-@Table(name="terms",
-        uniqueConstraints = {
-        @UniqueConstraint(
-                columnNames = {"name", "category_id"}
-        )
-    }
-)
+@Table(name="terms")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Term extends BaseEntity{

--- a/src/main/java/welkit_server/domain/terms/entity/Term.java
+++ b/src/main/java/welkit_server/domain/terms/entity/Term.java
@@ -16,7 +16,7 @@ import welkit_server.domain.user.entity.User;
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Term {
+public class Term extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/terms/entity/Term.java
+++ b/src/main/java/welkit_server/domain/terms/entity/Term.java
@@ -1,0 +1,39 @@
+package welkit_server.domain.terms.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import welkit_server.domain.user.entity.User;
+
+@Entity
+@Getter
+@Builder
+@Table(name="terms",
+        uniqueConstraints = {
+        @UniqueConstraint(
+                columnNames = {"name", "category_id"}
+        )
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Term {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable=false, length = 50)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String definition;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private TermCategory category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+}

--- a/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
+++ b/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
@@ -1,0 +1,26 @@
+package welkit_server.domain.terms.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import welkit_server.domain.user.entity.User;
+
+
+@Entity
+@Getter
+@Builder
+@Table(name="term_categories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TermCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, length = 50, nullable = false)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
+++ b/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
@@ -11,7 +11,7 @@ import welkit_server.domain.user.entity.User;
 @Table(name="term_categories")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class TermCategory {
+public class TermCategory extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/user/entity/LockSetting.java
+++ b/src/main/java/welkit_server/domain/user/entity/LockSetting.java
@@ -25,7 +25,7 @@ public class LockSetting extends BaseEntity{
     @Column(nullable = false, length = 25)
     private FeatureName featureName;
 
-    @Column(name = "is_locked", nullable = false)
+    @Column(name = "is_locked")
     private boolean isLocked;
 
 }

--- a/src/main/java/welkit_server/domain/user/entity/LockSetting.java
+++ b/src/main/java/welkit_server/domain/user/entity/LockSetting.java
@@ -11,7 +11,7 @@ import welkit_server.domain.user.model.FeatureName;
 @Table(name="lock_settings")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class LockSetting {
+public class LockSetting extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/user/entity/LockSetting.java
+++ b/src/main/java/welkit_server/domain/user/entity/LockSetting.java
@@ -1,0 +1,31 @@
+package welkit_server.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import welkit_server.domain.user.model.FeatureName;
+
+
+@Entity
+@Getter
+@Builder
+@Table(name="lock_settings")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LockSetting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 25)
+    private FeatureName featureName;
+
+    @Column(name = "is_locked", nullable = false)
+    private boolean isLocked;
+
+}

--- a/src/main/java/welkit_server/domain/user/entity/User.java
+++ b/src/main/java/welkit_server/domain/user/entity/User.java
@@ -1,0 +1,46 @@
+package welkit_server.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import welkit_server.domain.user.model.*;
+
+@Entity
+@Getter
+@Builder
+@Table(name="users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, length = 50)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 25)
+    private EmailType emailType;
+
+    @Column(name = "google_email", length = 50)
+    private String googleEmail;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(name = "job_role", nullable = false, length = 40)
+    private String jobRole;
+
+    @Column(name = "is_company_verified", nullable = false)
+    private boolean isCompanyVerified;
+
+    //기능 잠금 설정용 비밀번호
+    @Column(name = "lock_pin", length=45)
+    private String lockPin;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 25)
+    private UserType userType;
+
+}

--- a/src/main/java/welkit_server/domain/user/entity/User.java
+++ b/src/main/java/welkit_server/domain/user/entity/User.java
@@ -29,8 +29,9 @@ public class User extends BaseEntity{
     @Column(nullable = false)
     private String password;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "job_role", nullable = false, length = 40)
-    private String jobRole;
+    private JobRole jobRole;
 
     @Column(name = "is_company_verified", nullable = false)
     private boolean isCompanyVerified;

--- a/src/main/java/welkit_server/domain/user/entity/User.java
+++ b/src/main/java/welkit_server/domain/user/entity/User.java
@@ -40,8 +40,9 @@ public class User extends BaseEntity{
     @Column(name = "lock_pin", length=45)
     private String lockPin;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 25)
-    private UserType userType;
+    private UserType userType = UserType.USER;
 
 }

--- a/src/main/java/welkit_server/domain/user/entity/User.java
+++ b/src/main/java/welkit_server/domain/user/entity/User.java
@@ -10,7 +10,7 @@ import welkit_server.domain.user.model.*;
 @Table(name="users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class User {
+public class User extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/user/model/EmailType.java
+++ b/src/main/java/welkit_server/domain/user/model/EmailType.java
@@ -1,0 +1,6 @@
+package welkit_server.domain.user.model;
+
+public enum EmailType {
+    PERSONAL_EMAIL,
+    COMPANY_EMAIL;
+}

--- a/src/main/java/welkit_server/domain/user/model/FeatureName.java
+++ b/src/main/java/welkit_server/domain/user/model/FeatureName.java
@@ -1,0 +1,8 @@
+package welkit_server.domain.user.model;
+
+public enum FeatureName {
+    TERMS,
+    INSIGHT_CARDS,
+    RETROSPECTIVES,
+    COMMUNITY
+}

--- a/src/main/java/welkit_server/domain/user/model/JobRole.java
+++ b/src/main/java/welkit_server/domain/user/model/JobRole.java
@@ -1,0 +1,37 @@
+package welkit_server.domain.user.model;
+
+public enum JobRole {
+
+    PLANNING_STRATEGY("기획·전략"),
+    LEGAL_ADMIN_GENERAL("법무·사무·총무"),
+    HR("인사·HR"),
+    ACCOUNTING_TAX("회계·세무"),
+    MARKETING_AD_MD("마케팅·광고·MD"),
+    AI_DEVELOP_DATA("AI·개발·데이터"),
+    DESIGN("디자인"),
+    LOGISTICS_FOREIGN_TRADE("물류·무역"),
+    DRIVING_TRANSPORT_DELIVERY("운전·운송·배송"),
+    SALES("영업"),
+    CUSTOMER_SUPPORT_TM("고객상담·TM"),
+    FINANCE_INSURANCE("금융·보험"),
+    FOOD_BEVERAGE("식·음료"),
+    CUSTOMER_SERVICE_RETAIL("고객서비스·리테일"),
+    ENGINEERING_DESIGN("엔지니어링·설계"),
+    MANUFACTURING_PRODUCTION("제조·생산"),
+    EDUCATION("교육"),
+    ARCHITECTURE_FACILITY("건축·시설"),
+    MEDICAL_BIO("의료·바이오"),
+    MEDIA_CULTURE_SPORTS("미디어·문화·스포츠"),
+    PUBLIC_WELFARE("공공·복지");
+
+    private final String description;
+
+    JobRole(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+}

--- a/src/main/java/welkit_server/domain/user/model/UserType.java
+++ b/src/main/java/welkit_server/domain/user/model/UserType.java
@@ -1,0 +1,6 @@
+package welkit_server.domain.user.model;
+
+public enum UserType {
+    ADMIN,
+    USER
+}


### PR DESCRIPTION
## 🔥 Related Issues
-  #2 

## ✅ 작업 리스트
- [x] 커뮤니티 도메인 설계 
- [x] 인사이트 카드 도메인 설계
- [x] 마이페이지 도메인 설계
- [x] 회고 도메인 설계
- [x] 용어 사전 도메인 설계
- [x] 유저 도메인 설계

## 🔧 작업 내용
- **각 기능별 엔티티 추가 및 필드 추가**
- **커뮤니티 도메인**: `CommunityFeedBack` 엔티티에 `@Table(uniqueConstraints = {"target_type", "target_id", "user_id"})` 적용함으로써, 동일 유저가 동일 대상에 중복 피드백 불가
- **연관관계(ManyToOne, OneToMany) 및 Enum 타입 필드 설계**

## 🤔 궁금한점

## 📸 ScreenShot