### PR TITLE
사용자 이메일 인증 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'io.lettuce:lettuce-core'
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 	//mail

--- a/src/main/java/welkit_server/domain/community/entity/CommunityComments.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityComments.java
@@ -3,6 +3,7 @@ package welkit_server.domain.community.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import welkit_server.domain.user.entity.User;
+import welkit_server.global.domain.BaseEntity;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,7 +14,7 @@ import java.util.List;
 @Table(name="community_comments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class CommunityComments extends BaseEntity{
+public class CommunityComments extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/community/entity/CommunityFeedBack.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityFeedBack.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import welkit_server.domain.community.model.TargetType;
 import welkit_server.domain.user.entity.User;
+import welkit_server.global.domain.BaseEntity;
 
 @Entity
 @Getter
@@ -17,7 +18,7 @@ import welkit_server.domain.user.entity.User;
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class CommunityFeedBack extends BaseEntity{
+public class CommunityFeedBack extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/community/entity/CommunityPosts.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityPosts.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import welkit_server.domain.community.model.CommunityPostStatus;
 import welkit_server.domain.user.entity.User;
+import welkit_server.global.domain.BaseEntity;
 
 @Entity
 @Getter
@@ -11,7 +12,7 @@ import welkit_server.domain.user.entity.User;
 @Table(name="community_posts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class CommunityPosts extends BaseEntity{
+public class CommunityPosts extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
+++ b/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
@@ -22,14 +22,14 @@ public class InsightCard extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String title;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String description;
 
     @Column(columnDefinition = "TEXT")
     private String note;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false,length = 25)
+    @Column(nullable = false, length = 25)
     private CardType cardType;
 
     @Column(name = "is_favorite", nullable = false)

--- a/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
+++ b/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import welkit_server.domain.insightcard.model.CardType;
 import welkit_server.domain.user.entity.User;
+import welkit_server.global.domain.BaseEntity;
 import java.time.LocalDateTime;
 
 @Entity
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @Table(name="insight_cards")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class InsightCard extends BaseEntity{
+public class InsightCard extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/mypage/entity/Notice.java
+++ b/src/main/java/welkit_server/domain/mypage/entity/Notice.java
@@ -3,6 +3,7 @@ package welkit_server.domain.mypage.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import welkit_server.domain.mypage.model.NoticePriority;
+import welkit_server.global.domain.BaseEntity;
 
 @Entity
 @Getter
@@ -10,7 +11,7 @@ import welkit_server.domain.mypage.model.NoticePriority;
 @Table(name="notices")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Notice extends BaseEntity{
+public class Notice extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/mypage/entity/Notice.java
+++ b/src/main/java/welkit_server/domain/mypage/entity/Notice.java
@@ -20,7 +20,7 @@ public class Notice extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String title;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/welkit_server/domain/retrospectives/entity/Retrospective.java
+++ b/src/main/java/welkit_server/domain/retrospectives/entity/Retrospective.java
@@ -22,7 +22,7 @@ public class Retrospective extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String title;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/welkit_server/domain/retrospectives/entity/Retrospective.java
+++ b/src/main/java/welkit_server/domain/retrospectives/entity/Retrospective.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import welkit_server.domain.retrospectives.model.Type;
 import welkit_server.domain.user.entity.User;
+import welkit_server.global.domain.BaseEntity;
 import java.time.LocalDate;
 
 @Entity
@@ -12,7 +13,7 @@ import java.time.LocalDate;
 @Table(name="retrospectives")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Retrospective extends BaseEntity{
+public class Retrospective extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/terms/entity/Term.java
+++ b/src/main/java/welkit_server/domain/terms/entity/Term.java
@@ -3,6 +3,7 @@ package welkit_server.domain.terms.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import welkit_server.domain.user.entity.User;
+import welkit_server.global.domain.BaseEntity;
 
 @Entity
 @Getter
@@ -10,7 +11,7 @@ import welkit_server.domain.user.entity.User;
 @Table(name="terms")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Term extends BaseEntity{
+public class Term extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/terms/entity/Term.java
+++ b/src/main/java/welkit_server/domain/terms/entity/Term.java
@@ -17,10 +17,10 @@ public class Term extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable=false, length = 50)
+    @Column(nullable = false, length = 50)
     private String name;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String definition;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
+++ b/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
@@ -3,6 +3,7 @@ package welkit_server.domain.terms.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import welkit_server.domain.user.entity.User;
+import welkit_server.global.domain.BaseEntity;
 
 
 @Entity
@@ -11,7 +12,7 @@ import welkit_server.domain.user.entity.User;
 @Table(name="term_categories")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class TermCategory extends BaseEntity{
+public class TermCategory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
+++ b/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
@@ -18,7 +18,7 @@ public class TermCategory extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, length = 50, nullable = false)
+    @Column(nullable = false, unique = true, length = 50)
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/welkit_server/domain/user/entity/LockSetting.java
+++ b/src/main/java/welkit_server/domain/user/entity/LockSetting.java
@@ -3,6 +3,7 @@ package welkit_server.domain.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import welkit_server.domain.user.model.FeatureName;
+import welkit_server.global.domain.BaseEntity;
 
 
 @Entity
@@ -11,7 +12,7 @@ import welkit_server.domain.user.model.FeatureName;
 @Table(name="lock_settings")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class LockSetting extends BaseEntity{
+public class LockSetting extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/user/entity/User.java
+++ b/src/main/java/welkit_server/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package welkit_server.domain.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import welkit_server.domain.user.model.*;
+import welkit_server.global.domain.BaseEntity;
 
 @Entity
 @Getter
@@ -10,7 +11,7 @@ import welkit_server.domain.user.model.*;
 @Table(name="users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class User extends BaseEntity{
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/welkit_server/domain/user/mail/controller/EmailController.java
+++ b/src/main/java/welkit_server/domain/user/mail/controller/EmailController.java
@@ -26,87 +26,28 @@ public class EmailController {
 
     @Operation(summary = "회사 이메일 인증 코드 전송", description = "5분간 유효한 이메일 인증 코드를 전송합니다. ")
     @PostMapping("/company/email")
-    public ResponseEntity sendCompanyMail(@RequestBody EmailPostRequest emailPostRequest) {
-        EmailMessageResponse emailMessageResponse = EmailMessageResponse.builder()
-                .to(emailPostRequest.getEmail())
-                .subject("[welkit] 회사 이메일 인증을 위한 인증 코드 발송")
-                .build();
-
-        String code = emailService.sendMail(emailMessageResponse, "email");
-        redisUtil.saveEmailCode(emailPostRequest.getEmail(), code);
-
-        EmailResponse emailResponse = EmailResponse.builder()
-                .code(code)
-                .message("인증코드 전송 완료")
-                .build();
-        return ResponseEntity.ok(emailResponse);
-    }
-
-    @Operation(summary = "개인 이메일 인증 코드 전송", description = "5분간 유효한 이메일 인증 코드를 전송합니다. ")
-    @PostMapping("/personal/email")
-    public ResponseEntity sendPersonalMail(@RequestBody EmailPostRequest emailPostRequest) {
-        EmailMessageResponse emailMessageResponse = EmailMessageResponse.builder()
-                .to(emailPostRequest.getEmail())
-                .subject("[welkit] 개인 이메일 인증을 위한 인증 코드 발송")
-                .build();
-
-        String code = emailService.sendMail(emailMessageResponse, "email");
-        redisUtil.saveEmailCode(emailPostRequest.getEmail(), code);
-
-        EmailResponse emailResponse = EmailResponse.builder()
-                .code(code)
-                .message("인증코드 전송 완료")
-                .build();
-        return ResponseEntity.ok(emailResponse);
+    public ResponseEntity<EmailResponse> sendCompanyMail(@RequestBody EmailPostRequest emailPostRequest) {
+        return ResponseEntity.ok(emailService.sendVerificationEmail(emailPostRequest.getEmail(), "회사"));
     }
 
     @Operation(summary = "회사 이메일 인증 코드 검증", description = "전송된 인증 코드와 입력값을 비교하여 인증합니다")
     @PutMapping("/company/email")
-    public ResponseEntity<?> verifyCompanyEmail(@Valid @RequestBody EmailVerifyRequest emailVerifyRequest) {
-        String emailCode = redisUtil.getEmailCode(emailVerifyRequest.getEmail());
-        
-        if(emailCode == null) {
-            log.warn("회사 이메일 인증 코드 없음 또는 만료됨 - email: {}", emailVerifyRequest.getEmail());
-            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR); //EMAIL CODE EXPIRED
-        }
-        if (!emailCode.equals(emailVerifyRequest.getCode().trim())) {
-            log.warn("회사 이메일 인증 코드 불일치 - email: {}, 입력된 코드: {}", emailVerifyRequest.getEmail(), emailVerifyRequest.getCode());
-            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR); //ERROR CODE NOT MATCH
-        }
-        try {
-            redisUtil.saveVerifiedEmail(emailVerifyRequest.getEmail());
-            redisUtil.deleteEmailCode(emailVerifyRequest.getEmail());
-        } catch (Exception e) {
-            log.error("Redis 처리 중 오류 - email: {}", emailVerifyRequest.getEmail(), e);
-            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR);
-        }
+    public ResponseEntity<String> verifyCompanyEmail(@Valid @RequestBody EmailVerifyRequest emailVerifyRequest) {
+        emailService.verifyEmail(emailVerifyRequest.getEmail(), emailVerifyRequest.getCode(), "회사");
+        return ResponseEntity.ok("회사 이메일 인증이 완료되었습니다.");
+    }
 
-        log.info("회사 이메일 인증 성공 - email: {}", emailVerifyRequest.getEmail());
-        return ResponseEntity.ok("개인 이메일 인증이 완료되었습니다.");
+    @Operation(summary = "개인 이메일 인증 코드 전송", description = "5분간 유효한 이메일 인증 코드를 전송합니다. ")
+    @PostMapping("/personal/email")
+    public ResponseEntity<EmailResponse> sendPersonalMail(@RequestBody EmailPostRequest emailPostRequest) {
+        return ResponseEntity.ok(emailService.sendVerificationEmail(emailPostRequest.getEmail(), "개인"));
     }
 
     @Operation(summary = "개인 이메일 인증 코드 검증", description = "전송된 인증 코드와 입력값을 비교하여 인증합니다")
     @PutMapping("/personal/email")
-    public ResponseEntity<?> verifyPersonalEmail(@Valid @RequestBody EmailVerifyRequest emailVerifyRequest) {
-        String emailCode = redisUtil.getEmailCode(emailVerifyRequest.getEmail());
-
-        if(emailCode == null) {
-            log.warn("개인 이메일 인증 코드 없음 또는 만료됨 - email: {}", emailVerifyRequest.getEmail());
-            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR); //EMAIL CODE EXPIRED
-        }
-        if (!emailCode.equals(emailVerifyRequest.getCode().trim())) {
-            log.warn("개인 이메일 인증 코드 불일치 - email: {}, 입력된 코드: {}", emailVerifyRequest.getEmail(), emailVerifyRequest.getCode());
-            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR); //ERROR CODE NOT MATCH
-        }
-        try {
-            redisUtil.saveVerifiedEmail(emailVerifyRequest.getEmail());
-            redisUtil.deleteEmailCode(emailVerifyRequest.getEmail());
-        } catch (Exception e) {
-            log.error("Redis 처리 중 오류 - email: {}", emailVerifyRequest.getEmail(), e);
-            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR);
-        }
-
-        log.info("개인 이메일 인증 성공 - email: {}", emailVerifyRequest.getEmail());
+    public ResponseEntity<String> verifyPersonalEmail(@Valid @RequestBody EmailVerifyRequest emailVerifyRequest) {
+        emailService.verifyEmail(emailVerifyRequest.getEmail(), emailVerifyRequest.getCode(), "개인");
         return ResponseEntity.ok("개인 이메일 인증이 완료되었습니다.");
     }
+
 }

--- a/src/main/java/welkit_server/domain/user/mail/controller/EmailController.java
+++ b/src/main/java/welkit_server/domain/user/mail/controller/EmailController.java
@@ -1,0 +1,112 @@
+package welkit_server.domain.user.mail.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import welkit_server.domain.user.mail.dto.request.EmailPostRequest;
+import welkit_server.domain.user.mail.dto.request.EmailVerifyRequest;
+import welkit_server.domain.user.mail.dto.response.EmailMessageResponse;
+import welkit_server.domain.user.mail.dto.response.EmailResponse;
+import welkit_server.domain.user.mail.service.EmailService;
+import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.BadRequestException;
+import welkit_server.global.redis.RedisUtil;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/signup")
+@Slf4j
+public class EmailController {
+
+    private final EmailService emailService;
+    private final RedisUtil redisUtil;
+
+    @Operation(summary = "회사 이메일 인증 코드 전송", description = "5분간 유효한 이메일 인증 코드를 전송합니다. ")
+    @PostMapping("/company/email")
+    public ResponseEntity sendCompanyMail(@RequestBody EmailPostRequest emailPostRequest) {
+        EmailMessageResponse emailMessageResponse = EmailMessageResponse.builder()
+                .to(emailPostRequest.getEmail())
+                .subject("[welkit] 회사 이메일 인증을 위한 인증 코드 발송")
+                .build();
+
+        String code = emailService.sendMail(emailMessageResponse, "email");
+        redisUtil.saveEmailCode(emailPostRequest.getEmail(), code);
+
+        EmailResponse emailResponse = EmailResponse.builder()
+                .code(code)
+                .message("인증코드 전송 완료")
+                .build();
+        return ResponseEntity.ok(emailResponse);
+    }
+
+    @Operation(summary = "개인 이메일 인증 코드 전송", description = "5분간 유효한 이메일 인증 코드를 전송합니다. ")
+    @PostMapping("/personal/email")
+    public ResponseEntity sendPersonalMail(@RequestBody EmailPostRequest emailPostRequest) {
+        EmailMessageResponse emailMessageResponse = EmailMessageResponse.builder()
+                .to(emailPostRequest.getEmail())
+                .subject("[welkit] 개인 이메일 인증을 위한 인증 코드 발송")
+                .build();
+
+        String code = emailService.sendMail(emailMessageResponse, "email");
+        redisUtil.saveEmailCode(emailPostRequest.getEmail(), code);
+
+        EmailResponse emailResponse = EmailResponse.builder()
+                .code(code)
+                .message("인증코드 전송 완료")
+                .build();
+        return ResponseEntity.ok(emailResponse);
+    }
+
+    @Operation(summary = "회사 이메일 인증 코드 검증", description = "전송된 인증 코드와 입력값을 비교하여 인증합니다")
+    @PutMapping("/company/email")
+    public ResponseEntity<?> verifyCompanyEmail(@Valid @RequestBody EmailVerifyRequest emailVerifyRequest) {
+        String emailCode = redisUtil.getEmailCode(emailVerifyRequest.getEmail());
+        
+        if(emailCode == null) {
+            log.warn("회사 이메일 인증 코드 없음 또는 만료됨 - email: {}", emailVerifyRequest.getEmail());
+            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR); //EMAIL CODE EXPIRED
+        }
+        if (!emailCode.equals(emailVerifyRequest.getCode().trim())) {
+            log.warn("회사 이메일 인증 코드 불일치 - email: {}, 입력된 코드: {}", emailVerifyRequest.getEmail(), emailVerifyRequest.getCode());
+            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR); //ERROR CODE NOT MATCH
+        }
+        try {
+            redisUtil.saveVerifiedEmail(emailVerifyRequest.getEmail());
+            redisUtil.deleteEmailCode(emailVerifyRequest.getEmail());
+        } catch (Exception e) {
+            log.error("Redis 처리 중 오류 - email: {}", emailVerifyRequest.getEmail(), e);
+            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+
+        log.info("회사 이메일 인증 성공 - email: {}", emailVerifyRequest.getEmail());
+        return ResponseEntity.ok("개인 이메일 인증이 완료되었습니다.");
+    }
+
+    @Operation(summary = "개인 이메일 인증 코드 검증", description = "전송된 인증 코드와 입력값을 비교하여 인증합니다")
+    @PutMapping("/personal/email")
+    public ResponseEntity<?> verifyPersonalEmail(@Valid @RequestBody EmailVerifyRequest emailVerifyRequest) {
+        String emailCode = redisUtil.getEmailCode(emailVerifyRequest.getEmail());
+
+        if(emailCode == null) {
+            log.warn("개인 이메일 인증 코드 없음 또는 만료됨 - email: {}", emailVerifyRequest.getEmail());
+            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR); //EMAIL CODE EXPIRED
+        }
+        if (!emailCode.equals(emailVerifyRequest.getCode().trim())) {
+            log.warn("개인 이메일 인증 코드 불일치 - email: {}, 입력된 코드: {}", emailVerifyRequest.getEmail(), emailVerifyRequest.getCode());
+            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR); //ERROR CODE NOT MATCH
+        }
+        try {
+            redisUtil.saveVerifiedEmail(emailVerifyRequest.getEmail());
+            redisUtil.deleteEmailCode(emailVerifyRequest.getEmail());
+        } catch (Exception e) {
+            log.error("Redis 처리 중 오류 - email: {}", emailVerifyRequest.getEmail(), e);
+            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+
+        log.info("개인 이메일 인증 성공 - email: {}", emailVerifyRequest.getEmail());
+        return ResponseEntity.ok("개인 이메일 인증이 완료되었습니다.");
+    }
+}

--- a/src/main/java/welkit_server/domain/user/mail/dto/request/EmailPostRequest.java
+++ b/src/main/java/welkit_server/domain/user/mail/dto/request/EmailPostRequest.java
@@ -1,0 +1,16 @@
+package welkit_server.domain.user.mail.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class EmailPostRequest {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이어야 합니다")
+    private String email;
+
+}

--- a/src/main/java/welkit_server/domain/user/mail/dto/request/EmailVerifyRequest.java
+++ b/src/main/java/welkit_server/domain/user/mail/dto/request/EmailVerifyRequest.java
@@ -14,4 +14,5 @@ public class EmailVerifyRequest {
 
     @NotBlank(message = "인증 코드는 필수 입니다")
     private String code;
+
 }

--- a/src/main/java/welkit_server/domain/user/mail/dto/request/EmailVerifyRequest.java
+++ b/src/main/java/welkit_server/domain/user/mail/dto/request/EmailVerifyRequest.java
@@ -1,0 +1,17 @@
+package welkit_server.domain.user.mail.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class EmailVerifyRequest {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    private String email;
+
+    @NotBlank(message = "인증 코드는 필수 입니다")
+    private String code;
+}

--- a/src/main/java/welkit_server/domain/user/mail/dto/response/EmailMessageResponse.java
+++ b/src/main/java/welkit_server/domain/user/mail/dto/response/EmailMessageResponse.java
@@ -1,0 +1,13 @@
+package welkit_server.domain.user.mail.dto.response;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class EmailMessageResponse {
+
+    private String to;
+    private String subject;
+    private String message;
+}

--- a/src/main/java/welkit_server/domain/user/mail/dto/response/EmailResponse.java
+++ b/src/main/java/welkit_server/domain/user/mail/dto/response/EmailResponse.java
@@ -1,0 +1,13 @@
+package welkit_server.domain.user.mail.dto.response;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class EmailResponse {
+
+    private String code;
+    private String message;
+}

--- a/src/main/java/welkit_server/domain/user/mail/service/EmailService.java
+++ b/src/main/java/welkit_server/domain/user/mail/service/EmailService.java
@@ -1,0 +1,50 @@
+package welkit_server.domain.user.mail.service;
+
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import welkit_server.domain.user.mail.dto.response.EmailMessageResponse;
+import welkit_server.global.redis.RedisKey;
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public String sendMail(EmailMessageResponse emailMessage, String type){
+        String authNum = createCode();
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        try{
+            if (type.equals("email")) {
+                mimeMessage.setRecipients(Message.RecipientType.TO, emailMessage.getTo());
+                mimeMessage.setSubject(emailMessage.getSubject());
+                mimeMessage.setText("인증번호: " + authNum, "utf-8");
+                mailSender.send(mimeMessage);
+                redisTemplate.opsForValue().set(RedisKey.EMAIL_CODE.getKey(emailMessage.getTo()), authNum, RedisKey.EMAIL_CODE.getTtl() );
+            }
+        }catch (MessagingException e){
+            log.error("메일 전송 실패", e);
+            throw new RuntimeException("메일 전송 실패");
+        }
+        return authNum;
+    }
+
+    public String createCode() {
+        Random random = new Random();
+        StringBuilder key = new StringBuilder();
+
+        for (int i = 0; i < 6; i++) {
+            key.append(random.nextInt(10)); // 0 - 9
+        }
+        return key.toString();
+    }
+}

--- a/src/main/java/welkit_server/domain/user/mail/service/EmailService.java
+++ b/src/main/java/welkit_server/domain/user/mail/service/EmailService.java
@@ -9,7 +9,12 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import welkit_server.domain.user.mail.dto.response.EmailMessageResponse;
+import welkit_server.domain.user.mail.dto.response.EmailResponse;
+import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.BadRequestException;
 import welkit_server.global.redis.RedisKey;
+import welkit_server.global.redis.RedisUtil;
+
 import java.util.Random;
 
 @Slf4j
@@ -19,6 +24,22 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
     private final RedisTemplate<String, String> redisTemplate;
+    private final RedisUtil redisUtil;
+
+    public EmailResponse sendVerificationEmail(String email, String type) {
+        EmailMessageResponse emailMessageResponse = EmailMessageResponse.builder()
+                .to(email)
+                .subject("[welkit] " + type + " 이메일 인증을 위한 인증 코드 발송")
+                .build();
+
+        String code = sendMail(emailMessageResponse, "email");
+        redisUtil.saveEmailCode(email, code);
+
+        return EmailResponse.builder()
+                .code(code)
+                .message("인증코드 전송 완료")
+                .build();
+    }
 
     public String sendMail(EmailMessageResponse emailMessage, String type){
         String authNum = createCode();
@@ -38,6 +59,29 @@ public class EmailService {
         return authNum;
     }
 
+    public void verifyEmail(String email, String inputCode, String type) {
+        String emailCode = redisUtil.getEmailCode(email);
+
+        if (emailCode == null) {
+            log.warn("{} 이메일 인증 코드 없음 또는 만료됨 - email: {}", type, email);
+            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR); //EMAIL CODE EXPIRED
+        }
+
+        if (!emailCode.equals(inputCode.trim())) {
+            log.warn("{} 이메일 인증 코드 불일치 - email: {}, 입력된 코드: {}", type, email, inputCode);
+            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR); //ERROR CODE NOT MATCH
+        }
+
+        try {
+            redisUtil.saveVerifiedEmail(email);
+            redisUtil.deleteEmailCode(email);
+        } catch (Exception e) {
+            log.error("Redis 처리 중 오류 - email: {}", email, e);
+            throw new BadRequestException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+        log.info("{} 이메일 인증 성공 - email: {}", type, email);
+    }
+
     public String createCode() {
         Random random = new Random();
         StringBuilder key = new StringBuilder();
@@ -47,4 +91,5 @@ public class EmailService {
         }
         return key.toString();
     }
+
 }

--- a/src/main/java/welkit_server/global/redis/RedisConfig.java
+++ b/src/main/java/welkit_server/global/redis/RedisConfig.java
@@ -1,0 +1,36 @@
+package welkit_server.global.redis;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.*;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@Slf4j
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        log.info("Connecting to Redis at {}:{}", redisHost, redisPort);
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+
+}

--- a/src/main/java/welkit_server/global/redis/RedisKey.java
+++ b/src/main/java/welkit_server/global/redis/RedisKey.java
@@ -1,0 +1,24 @@
+package welkit_server.global.redis;
+
+import lombok.Getter;
+import java.time.Duration;
+
+@Getter
+public enum RedisKey {
+
+    EMAIL_CODE("emailCode:", Duration.ofMinutes(5)),
+    VERIFIED_EMAIL("verified:", Duration.ofMinutes(10));
+
+    private final String prefix;
+    private final Duration ttl;
+
+    RedisKey(String prefix, Duration ttl) {
+        this.prefix = prefix;
+        this.ttl = ttl;
+    }
+
+    public String getKey(String value) {
+        return prefix + value;
+    }
+
+}

--- a/src/main/java/welkit_server/global/redis/RedisUtil.java
+++ b/src/main/java/welkit_server/global/redis/RedisUtil.java
@@ -1,0 +1,43 @@
+package welkit_server.global.redis;
+
+import jakarta.annotation.PostConstruct;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @PostConstruct
+    public void init() {
+        log.info("RedisUtil 초기화 : RedisTemplate = {}", redisTemplate);
+    }
+
+    public void saveEmailCode(String email, String code) {
+        log.info("Redis 저장 시도: email = {}, code = {}", email, code);
+        redisTemplate.opsForValue().set(RedisKey.EMAIL_CODE.getKey(email), code, RedisKey.EMAIL_CODE.getTtl());
+    }
+
+    public String getEmailCode(String email) {
+        return redisTemplate.opsForValue().get(RedisKey.EMAIL_CODE.getKey(email));
+    }
+
+    public void deleteEmailCode(String email) {
+        redisTemplate.delete(RedisKey.EMAIL_CODE.getKey(email));
+    }
+
+    public void saveVerifiedEmail(String email) {
+        redisTemplate.opsForValue().set(RedisKey.VERIFIED_EMAIL.getKey(email), "true" , RedisKey.VERIFIED_EMAIL.getTtl());
+    }
+
+    public boolean isVerifiedEmail(String email) {
+        String result = redisTemplate.opsForValue().get(RedisKey.VERIFIED_EMAIL.getKey(email));
+        return "true".equals(result);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,10 @@
 spring:
   profiles:
     active: local
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.timeout: 5000
+      mail.smtp.starttls.enable: true


### PR DESCRIPTION
## 🔥 Related Issues
- #6 

## ✅ 작업 리스트
- [x] 엔티티 필드 필수 입력 처리
- [x] 사용자 이메일 인증 기능 구현

## 🔧 작업 내용
- 회사/개인 이메일 인증 코드 전송 API 구현 (Redis에 5분 유효 코드 저장)
- 이메일 인증 코드 검증 API 구현 (입력값과 Redis 저장 값 비교 후 검증 처리)
- 중복되는 메일 전송 로직을 서비스 계층(EmailService)으로 분리하여 컨트롤러 단순화
- 이메일 인증 성공 시 Redis에 인증 완료 상태 저장 및 인증 코드 삭제 처리

## 🤔 궁금한점


## 📸 ScreenShot
