### PR TITLE
용어 사전 기능 구현

### DIFF
--- a/src/main/java/welkit_server/domain/terms/controller/TermController.java
+++ b/src/main/java/welkit_server/domain/terms/controller/TermController.java
@@ -10,9 +10,13 @@ import welkit_server.domain.terms.dto.request.CreateTermRequest;
 import welkit_server.domain.terms.dto.request.EditTermRequest;
 import welkit_server.domain.terms.dto.response.EditTermResponse;
 import welkit_server.domain.terms.dto.response.CreateTermResponse;
+import welkit_server.domain.terms.dto.response.GetAllTermResponse;
+import welkit_server.domain.terms.dto.response.GetCategoryTermResponse;
 import welkit_server.domain.terms.service.TermService;
 import welkit_server.global.dto.SuccessResponse;
 import welkit_server.global.exception.message.SuccessMessage;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +24,20 @@ import welkit_server.global.exception.message.SuccessMessage;
 public class TermController {
 
     private final TermService termService;
+
+    @Operation(summary = "용어 조회", description = "등록된 용어를 조회합니다")
+    @GetMapping
+    public ResponseEntity<SuccessResponse<?>> getTerms(
+            @RequestParam(value = "categoryId", required = false) Long categoryId
+    ) {
+        if(categoryId != null){
+            List<GetCategoryTermResponse> terms = termService.getCategoryTerms(categoryId);
+            return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, terms));
+        } else {
+            List<GetAllTermResponse> terms = termService.getTerms();
+            return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, terms));
+        }
+    }
 
     @Operation(summary = "용어 등록", description = "새로운 용어를 등록합니다")
     @PostMapping
@@ -29,7 +47,7 @@ public class TermController {
         return ResponseEntity.status(HttpStatus.CREATED).body(body);
     }
 
-    @Operation(summary = "용어 수정", description = "기존에 등록되어 있는 용어를 수정합니다")
+    @Operation(summary = "용어 수정", description = "등록되어 있는 용어를 수정합니다")
     @PatchMapping("/{id}")
     public ResponseEntity<SuccessResponse<EditTermResponse>> updateTerm(
             @PathVariable("id") Long termId,
@@ -40,11 +58,11 @@ public class TermController {
         return new ResponseEntity<>(body, HttpStatus.OK);
     }
 
-    @Operation(summary = "용어 삭제", description = "기존에 등록되어 있는 용어를 삭제합니다")
+    @Operation(summary = "용어 삭제", description = "등록되어 있는 용어를 삭제합니다")
     @DeleteMapping("/{id}")
     public ResponseEntity<SuccessResponse> deleteTerm(@PathVariable("id") Long termId){
         termService.deleteTerm(termId);
-        return new ResponseEntity<>(SuccessResponse.of(SuccessMessage.DELETED_SUCCESS), HttpStatus.OK);
+        return new ResponseEntity<>(SuccessResponse.of(SuccessMessage.DELETED_SUCCESS), HttpStatus.NO_CONTENT);
     }
 
 }

--- a/src/main/java/welkit_server/domain/terms/controller/TermController.java
+++ b/src/main/java/welkit_server/domain/terms/controller/TermController.java
@@ -1,0 +1,25 @@
+package welkit_server.domain.terms.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import welkit_server.domain.terms.dto.request.CreateTermRequest;
+import welkit_server.domain.terms.dto.response.TermResponse;
+import welkit_server.domain.terms.service.TermService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/terms")
+public class TermController {
+
+    private final TermService termService;
+
+    @Operation(summary = "용어 사전 용어 등록", description = "새로운 용어를 등록합니다")
+    @PostMapping
+    public ResponseEntity<TermResponse> createTerm(@Valid @RequestBody CreateTermRequest createTerm){
+        TermResponse termResponse = termService.createTerm(createTerm);
+        return ResponseEntity.ok(termResponse);
+    }
+}

--- a/src/main/java/welkit_server/domain/terms/controller/TermController.java
+++ b/src/main/java/welkit_server/domain/terms/controller/TermController.java
@@ -3,11 +3,16 @@ package welkit_server.domain.terms.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import welkit_server.domain.terms.dto.request.CreateTermRequest;
-import welkit_server.domain.terms.dto.response.TermResponse;
+import welkit_server.domain.terms.dto.request.EditTermRequest;
+import welkit_server.domain.terms.dto.response.EditTermResponse;
+import welkit_server.domain.terms.dto.response.CreateTermResponse;
 import welkit_server.domain.terms.service.TermService;
+import welkit_server.global.dto.SuccessResponse;
+import welkit_server.global.exception.message.SuccessMessage;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,10 +21,30 @@ public class TermController {
 
     private final TermService termService;
 
-    @Operation(summary = "용어 사전 용어 등록", description = "새로운 용어를 등록합니다")
+    @Operation(summary = "용어 등록", description = "새로운 용어를 등록합니다")
     @PostMapping
-    public ResponseEntity<TermResponse> createTerm(@Valid @RequestBody CreateTermRequest createTerm){
-        TermResponse termResponse = termService.createTerm(createTerm);
-        return ResponseEntity.ok(termResponse);
+    public ResponseEntity<SuccessResponse<CreateTermResponse>> createTerm(@Valid @RequestBody CreateTermRequest createTerm) {
+        CreateTermResponse createTermResponse = termService.createTerm(createTerm);
+        SuccessResponse<CreateTermResponse> body = SuccessResponse.of(SuccessMessage.CREATED_SUCCESS, createTermResponse);
+        return ResponseEntity.status(HttpStatus.CREATED).body(body);
     }
+
+    @Operation(summary = "용어 수정", description = "기존에 등록되어 있는 용어를 수정합니다")
+    @PatchMapping("/{id}")
+    public ResponseEntity<SuccessResponse<EditTermResponse>> updateTerm(
+            @PathVariable("id") Long termId,
+            @Valid @RequestBody EditTermRequest editTermRequest
+    ) {
+        EditTermResponse editTermResponse = termService.editTerm(termId, editTermRequest);
+        SuccessResponse<EditTermResponse> body = SuccessResponse.of(SuccessMessage.UPDATED_SUCCESS, editTermResponse);
+        return new ResponseEntity<>(body, HttpStatus.OK);
+    }
+
+    @Operation(summary = "용어 삭제", description = "기존에 등록되어 있는 용어를 삭제합니다")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponse> deleteTerm(@PathVariable("id") Long termId){
+        termService.deleteTerm(termId);
+        return new ResponseEntity<>(SuccessResponse.of(SuccessMessage.DELETED_SUCCESS), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
+++ b/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
@@ -26,4 +26,5 @@ public class CreateTermRequest {
                 .category(category)
                 .build();
     }
+
 }

--- a/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
+++ b/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
@@ -1,0 +1,32 @@
+package welkit_server.domain.terms.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import welkit_server.domain.terms.entity.Term;
+import welkit_server.domain.terms.entity.TermCategory;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateTermRequest {
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String definition;
+
+    private Long categoryId;
+
+    @NotBlank
+    private String categoryName;
+
+    public Term toEntity(TermCategory category) {
+        return Term.builder()
+                .name(name)
+                .definition(definition)
+                .category(category)
+                .build();
+    }
+}

--- a/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
+++ b/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
@@ -1,28 +1,29 @@
 package welkit_server.domain.terms.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import welkit_server.domain.terms.entity.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class CreateTermRequest {
 
     @NotBlank
     private String name;
-
     @NotBlank
     private String definition;
-
+    @NotNull
     private Long categoryId;
-
     @NotBlank
     private String categoryName;
 
     public Term toEntity(TermCategory category) {
         return Term.builder()
-                .name(name)
-                .definition(definition)
+                .name(name.trim())
+                .definition(definition.trim())
                 .category(category)
                 .build();
     }

--- a/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
+++ b/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
@@ -1,11 +1,8 @@
 package welkit_server.domain.terms.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import welkit_server.domain.terms.entity.Term;
-import welkit_server.domain.terms.entity.TermCategory;
+import lombok.*;
+import welkit_server.domain.terms.entity.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/welkit_server/domain/terms/dto/request/EditTermRequest.java
+++ b/src/main/java/welkit_server/domain/terms/dto/request/EditTermRequest.java
@@ -1,14 +1,17 @@
 package welkit_server.domain.terms.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class EditTermRequest {
 
     private String name;
     private String definition;
+    @NotNull
     private Long categoryId;
     private String categoryName;
 

--- a/src/main/java/welkit_server/domain/terms/dto/request/EditTermRequest.java
+++ b/src/main/java/welkit_server/domain/terms/dto/request/EditTermRequest.java
@@ -1,0 +1,14 @@
+package welkit_server.domain.terms.dto.request;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class EditTermRequest {
+
+    private String name;
+    private String definition;
+    private Long categoryId;
+    private String categoryName;
+}

--- a/src/main/java/welkit_server/domain/terms/dto/response/CreateTermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/CreateTermResponse.java
@@ -3,8 +3,9 @@ package welkit_server.domain.terms.dto.response;
 import lombok.*;
 
 @Getter
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class CreateTermResponse {
 
     private Long termId;

--- a/src/main/java/welkit_server/domain/terms/dto/response/CreateTermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/CreateTermResponse.java
@@ -1,0 +1,20 @@
+package welkit_server.domain.terms.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateTermResponse {
+
+    private Long termId;
+    private String name;
+    private String definition;
+    private Long categoryId;
+    private String categoryName;
+
+    public static CreateTermResponse of(Long termId, String name, String definition, Long categoryId, String categoryName) {
+        return new CreateTermResponse(termId, name, definition, categoryId, categoryName);
+    }
+
+}

--- a/src/main/java/welkit_server/domain/terms/dto/response/EditTermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/EditTermResponse.java
@@ -1,0 +1,19 @@
+package welkit_server.domain.terms.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class EditTermResponse {
+
+    private Long termId;
+    private String name;
+    private String definition;
+    private Long categoryId;
+
+    public static EditTermResponse of(Long termId, String name, String definition, Long categoryId) {
+        return new EditTermResponse(termId, name, definition, categoryId);
+    }
+
+}

--- a/src/main/java/welkit_server/domain/terms/dto/response/EditTermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/EditTermResponse.java
@@ -3,8 +3,9 @@ package welkit_server.domain.terms.dto.response;
 import lombok.*;
 
 @Getter
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class EditTermResponse {
 
     private Long termId;

--- a/src/main/java/welkit_server/domain/terms/dto/response/GetAllTermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/GetAllTermResponse.java
@@ -4,8 +4,9 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class GetAllTermResponse {
 
     private Long termId;

--- a/src/main/java/welkit_server/domain/terms/dto/response/GetAllTermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/GetAllTermResponse.java
@@ -1,0 +1,17 @@
+package welkit_server.domain.terms.dto.response;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetAllTermResponse {
+
+    private Long termId;
+    private String name;
+    private String definition;
+    private Long categoryId;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/welkit_server/domain/terms/dto/response/GetCategoryTermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/GetCategoryTermResponse.java
@@ -3,8 +3,9 @@ package welkit_server.domain.terms.dto.response;
 import lombok.*;
 
 @Getter
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class GetCategoryTermResponse {
 
     private Long termId;

--- a/src/main/java/welkit_server/domain/terms/dto/response/GetCategoryTermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/GetCategoryTermResponse.java
@@ -1,15 +1,15 @@
-package welkit_server.domain.terms.dto.request;
+package welkit_server.domain.terms.dto.response;
 
 import lombok.*;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class EditTermRequest {
+public class GetCategoryTermResponse {
 
+    private Long termId;
     private String name;
     private String definition;
     private Long categoryId;
-    private String categoryName;
 
 }

--- a/src/main/java/welkit_server/domain/terms/dto/response/TermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/TermResponse.java
@@ -1,9 +1,0 @@
-package welkit_server.domain.terms.dto.response;
-
-public record TermResponse(
-        Long termId,
-        String name,
-        String definition,
-        Long categoryId,
-        String categoryName
-) {}

--- a/src/main/java/welkit_server/domain/terms/dto/response/TermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/TermResponse.java
@@ -1,0 +1,9 @@
+package welkit_server.domain.terms.dto.response;
+
+public record TermResponse(
+        Long termId,
+        String name,
+        String definition,
+        Long categoryId,
+        String categoryName
+) {}

--- a/src/main/java/welkit_server/domain/terms/entity/Term.java
+++ b/src/main/java/welkit_server/domain/terms/entity/Term.java
@@ -2,6 +2,7 @@ package welkit_server.domain.terms.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import welkit_server.domain.terms.dto.request.EditTermRequest;
 import welkit_server.domain.user.entity.User;
 import welkit_server.global.domain.BaseEntity;
 
@@ -31,4 +32,15 @@ public class Term extends BaseEntity {
     @JoinColumn(name = "user_id") //nullable = false
     private User user;
 
+    public void editTerm(EditTermRequest editTermRequest, TermCategory newCategory) {
+        if (editTermRequest.getName() != null) {
+            this.name = editTermRequest.getName();
+        }
+        if (editTermRequest.getDefinition() != null) {
+            this.definition = editTermRequest.getDefinition();
+        }
+        if (newCategory != null) {
+            this.category = newCategory;
+        }
+    }
 }

--- a/src/main/java/welkit_server/domain/terms/entity/Term.java
+++ b/src/main/java/welkit_server/domain/terms/entity/Term.java
@@ -28,7 +28,7 @@ public class Term extends BaseEntity {
     private TermCategory category;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id") //nullable = false
     private User user;
 
 }

--- a/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
+++ b/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
@@ -22,6 +22,6 @@ public class TermCategory extends BaseEntity {
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="user_id", nullable = false)
+    @JoinColumn(name="user_id") //nullable = false
     private User user;
 }

--- a/src/main/java/welkit_server/domain/terms/repository/TermCategoryRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermCategoryRepository.java
@@ -1,0 +1,13 @@
+package welkit_server.domain.terms.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import welkit_server.domain.terms.entity.TermCategory;
+
+import java.util.Optional;
+
+@Repository
+public interface TermCategoryRepository extends JpaRepository<TermCategory, Long> {
+
+    Optional<TermCategory> findTermCategoryById(Long id);
+}

--- a/src/main/java/welkit_server/domain/terms/repository/TermCategoryRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermCategoryRepository.java
@@ -1,16 +1,13 @@
 package welkit_server.domain.terms.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-import welkit_server.domain.terms.entity.Term;
 import welkit_server.domain.terms.entity.TermCategory;
-
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface TermCategoryRepository extends JpaRepository<TermCategory, Long> {
 
     Optional<TermCategory> findTermCategoryById(Long id);
+
 }

--- a/src/main/java/welkit_server/domain/terms/repository/TermCategoryRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermCategoryRepository.java
@@ -1,9 +1,12 @@
 package welkit_server.domain.terms.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import welkit_server.domain.terms.entity.Term;
 import welkit_server.domain.terms.entity.TermCategory;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
@@ -1,0 +1,7 @@
+package welkit_server.domain.terms.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import welkit_server.domain.terms.entity.Term;
+
+public interface TermRepository extends JpaRepository<Term, Long> {
+}

--- a/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
@@ -3,5 +3,8 @@ package welkit_server.domain.terms.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import welkit_server.domain.terms.entity.Term;
 
+import java.util.Optional;
+
 public interface TermRepository extends JpaRepository<Term, Long> {
+    Optional<Term> findById(Long id);
 }

--- a/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
@@ -1,10 +1,20 @@
 package welkit_server.domain.terms.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import welkit_server.domain.terms.entity.Term;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TermRepository extends JpaRepository<Term, Long> {
+
     Optional<Term> findById(Long id);
+
+    @Query("SELECT t FROM Term t ORDER BY t.lastModifiedDate DESC")
+    List<Term> findAllTerms();
+
+    @Query("SELECT t FROM Term t WHERE t.category.id = :categoryId ORDER BY t.lastModifiedDate DESC")
+    List<Term> findAllTermsByCategoryId(Long categoryId);
+
 }

--- a/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
@@ -2,14 +2,12 @@ package welkit_server.domain.terms.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 import welkit_server.domain.terms.entity.Term;
-
 import java.util.List;
-import java.util.Optional;
 
+@Repository
 public interface TermRepository extends JpaRepository<Term, Long> {
-
-    Optional<Term> findById(Long id);
 
     @Query("SELECT t FROM Term t ORDER BY t.lastModifiedDate DESC")
     List<Term> findAllTerms();

--- a/src/main/java/welkit_server/domain/terms/service/TermCategoryService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermCategoryService.java
@@ -1,0 +1,22 @@
+package welkit_server.domain.terms.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import welkit_server.domain.terms.entity.TermCategory;
+import welkit_server.domain.terms.repository.TermCategoryRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TermCategoryService {
+
+    private final TermCategoryRepository termCategoryRepository;
+
+    public TermCategory findOrCreate(Long categoryId, String categoryName) {
+        return termCategoryRepository.findTermCategoryById(categoryId)
+                .orElseGet(() -> termCategoryRepository.save(
+                        TermCategory.builder().name(categoryName).build()
+                ));
+    }
+}

--- a/src/main/java/welkit_server/domain/terms/service/TermCategoryService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermCategoryService.java
@@ -8,15 +8,17 @@ import welkit_server.domain.terms.repository.TermCategoryRepository;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class TermCategoryService {
 
     private final TermCategoryRepository termCategoryRepository;
 
+    @Transactional
     public TermCategory findOrCreate(Long categoryId, String categoryName) {
         return termCategoryRepository.findTermCategoryById(categoryId)
                 .orElseGet(() -> termCategoryRepository.save(
                         TermCategory.builder().name(categoryName).build()
                 ));
     }
+
 }

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -7,11 +7,14 @@ import welkit_server.domain.terms.dto.request.CreateTermRequest;
 import welkit_server.domain.terms.dto.request.EditTermRequest;
 import welkit_server.domain.terms.dto.response.EditTermResponse;
 import welkit_server.domain.terms.dto.response.CreateTermResponse;
+import welkit_server.domain.terms.dto.response.GetAllTermResponse;
+import welkit_server.domain.terms.dto.response.GetCategoryTermResponse;
 import welkit_server.domain.terms.entity.Term;
 import welkit_server.domain.terms.entity.TermCategory;
 import welkit_server.domain.terms.repository.TermRepository;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.NotFoundException;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +23,31 @@ public class TermService {
 
     private final TermRepository termRepository;
     private final TermCategoryService termCategoryService;
+
+    public List<GetAllTermResponse> getTerms(){
+        List<Term> termList = termRepository.findAllTerms();
+        return termList.stream()
+                .map(term -> GetAllTermResponse.builder()
+                        .termId(term.getId())
+                        .name(term.getName())
+                        .definition(term.getDefinition())
+                        .categoryId(term.getCategory().getId())
+                        .updatedAt(term.getLastModifiedDate())
+                        .build())
+                .toList();
+    }
+
+    public List<GetCategoryTermResponse> getCategoryTerms(Long categoryId){
+        List<Term> sortedCategoryTerms = termRepository.findAllTermsByCategoryId(categoryId);
+        return sortedCategoryTerms.stream()
+                .map(term -> GetCategoryTermResponse.builder()
+                        .termId(term.getId())
+                        .name(term.getName())
+                        .definition(term.getDefinition())
+                        .categoryId(term.getCategory().getId())
+                        .build())
+                .toList();
+    }
 
     @Transactional
     public CreateTermResponse createTerm(CreateTermRequest createTermRequest) {
@@ -57,4 +85,5 @@ public class TermService {
         return termRepository.findById(termId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.TERM_NOT_FOUND));
     }
+
 }

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -1,0 +1,44 @@
+package welkit_server.domain.terms.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import welkit_server.domain.terms.dto.request.CreateTermRequest;
+import welkit_server.domain.terms.dto.response.TermResponse;
+import welkit_server.domain.terms.entity.Term;
+import welkit_server.domain.terms.entity.TermCategory;
+import welkit_server.domain.terms.repository.TermCategoryRepository;
+import welkit_server.domain.terms.repository.TermRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TermService {
+
+    private final TermCategoryRepository termCategoryRepository;
+    private final TermRepository termRepository;
+
+    public TermResponse createTerm(CreateTermRequest createTermRequest) {
+
+        TermCategory category = termCategoryRepository.findTermCategoryById(createTermRequest.getCategoryId())
+                .orElseGet( () -> {
+                   TermCategory newCategory = TermCategory.builder()
+                           .name(createTermRequest.getName())
+                           .build();
+                   return termCategoryRepository.save(newCategory);
+                });
+
+        Term term = createTermRequest.toEntity(category);
+        Term savedTerm = termRepository.save(term);
+
+        return new TermResponse(
+                savedTerm.getId(),
+                savedTerm.getName(),
+                savedTerm.getDefinition(),
+                category.getId(),
+                category.getName()
+        );
+    }
+
+
+}

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -11,8 +11,10 @@ import welkit_server.domain.terms.dto.response.GetAllTermResponse;
 import welkit_server.domain.terms.dto.response.GetCategoryTermResponse;
 import welkit_server.domain.terms.entity.Term;
 import welkit_server.domain.terms.entity.TermCategory;
+import welkit_server.domain.terms.repository.TermCategoryRepository;
 import welkit_server.domain.terms.repository.TermRepository;
 import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.BadRequestException;
 import welkit_server.global.exception.model.NotFoundException;
 import java.util.List;
 
@@ -22,6 +24,7 @@ import java.util.List;
 public class TermService {
 
     private final TermRepository termRepository;
+    private final TermCategoryRepository termCategoryRepository;
     private final TermCategoryService termCategoryService;
 
     public List<GetAllTermResponse> getTerms(){
@@ -38,6 +41,9 @@ public class TermService {
     }
 
     public List<GetCategoryTermResponse> getCategoryTerms(Long categoryId){
+        if(termCategoryRepository.findTermCategoryById(categoryId).isEmpty()) {
+            throw new BadRequestException(ErrorMessage.WK_ENUM_VALUE_BAD_REQUEST);
+        }
         List<Term> sortedCategoryTerms = termRepository.findAllTermsByCategoryId(categoryId);
         return sortedCategoryTerms.stream()
                 .map(term -> GetCategoryTermResponse.builder()

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -4,41 +4,57 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.terms.dto.request.CreateTermRequest;
-import welkit_server.domain.terms.dto.response.TermResponse;
+import welkit_server.domain.terms.dto.request.EditTermRequest;
+import welkit_server.domain.terms.dto.response.EditTermResponse;
+import welkit_server.domain.terms.dto.response.CreateTermResponse;
 import welkit_server.domain.terms.entity.Term;
 import welkit_server.domain.terms.entity.TermCategory;
-import welkit_server.domain.terms.repository.TermCategoryRepository;
 import welkit_server.domain.terms.repository.TermRepository;
+import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.NotFoundException;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class TermService {
 
-    private final TermCategoryRepository termCategoryRepository;
     private final TermRepository termRepository;
+    private final TermCategoryService termCategoryService;
 
-    public TermResponse createTerm(CreateTermRequest createTermRequest) {
-
-        TermCategory category = termCategoryRepository.findTermCategoryById(createTermRequest.getCategoryId())
-                .orElseGet( () -> {
-                   TermCategory newCategory = TermCategory.builder()
-                           .name(createTermRequest.getName())
-                           .build();
-                   return termCategoryRepository.save(newCategory);
-                });
-
-        Term term = createTermRequest.toEntity(category);
-        Term savedTerm = termRepository.save(term);
-
-        return new TermResponse(
-                savedTerm.getId(),
-                savedTerm.getName(),
-                savedTerm.getDefinition(),
+    @Transactional
+    public CreateTermResponse createTerm(CreateTermRequest createTermRequest) {
+        TermCategory category = termCategoryService.findOrCreate(createTermRequest.getCategoryId(), createTermRequest.getCategoryName());
+        Term term = termRepository.save(createTermRequest.toEntity(category));
+        return CreateTermResponse.of(
+                term.getId(),
+                term.getName(),
+                term.getDefinition(),
                 category.getId(),
                 category.getName()
         );
     }
 
+    @Transactional
+    public EditTermResponse editTerm(Long termId, EditTermRequest editTermRequest) {
+        Term term = getTermById(termId);
+        TermCategory category = termCategoryService.findOrCreate(editTermRequest.getCategoryId(), editTermRequest.getCategoryName());
+        term.editTerm(editTermRequest, category);
+        return EditTermResponse.of(
+                term.getId(),
+                term.getName(),
+                term.getDefinition(),
+                term.getCategory().getId()
+        );
+    }
 
+    @Transactional
+    public void deleteTerm(Long termId) {
+        Term term = getTermById(termId);
+        termRepository.delete(term);
+    }
+
+    public Term getTermById(Long termId) {
+        return termRepository.findById(termId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.TERM_NOT_FOUND));
+    }
 }

--- a/src/main/java/welkit_server/global/exception/message/SuccessMessage.java
+++ b/src/main/java/welkit_server/global/exception/message/SuccessMessage.java
@@ -19,12 +19,22 @@ public enum SuccessMessage {
     COMPANY_EMAIL_VERIFICATION_SUCCESS(HttpStatus.CREATED.value(), "회사 메일 인증이 완료되었습니다."),
     PERSONAL_EMAIL_VERIFICATION_SUCCESS(HttpStatus.CREATED.value(), "개인 메일 인증이 완료되었습니다."),
 
+    LOAD_SUCCESS(HttpStatus.OK.value(),"조회가 완료되었습니다"),
+    UPDATED_SUCCESS(HttpStatus.OK.value(), "수정이 완료되었습니다"),
+
     /*
     201 Created
      */
+    CREATED_SUCCESS(HttpStatus.CREATED.value(), "등록 완료되었습니다."),
+
     COMPANY_EMAIL_REGISTER_SUCCESS(HttpStatus.CREATED.value(), "회사 메일 회원가입이 완료되었습니다."),
     PERSONAL_EMAIL_REGISTER_SUCCESS(HttpStatus.CREATED.value(), "개인 메일 회원가입이 완료되었습니다."),
     GOOGLE_COMPANY_REGISTER_SUCCESS(HttpStatus.CREATED.value(), "구글 로그인을 통한 회사 인증 회원가입이 완료되었습니다."),
+
+    /*
+    204 No Content
+     */
+    DELETED_SUCCESS(HttpStatus.NO_CONTENT.value(), "삭제가 완료되었습니다");
     ;
 
     private final int status;


### PR DESCRIPTION
## 🔥 Related Issues
- #11
## ✅ 작업 리스트
- [x] 카테고리별 용어 조회 기능 구현
- [x] 전체 용어 조회 기능 구현
- [x] 용어 등록 / 수정 / 삭제 기능 구현
- [x] 예외처리
## 🔧 작업 내용
- 카테고리별 용어 조회
  - 카테고리 ID 기준 용어 목록 조회 API 구현
  - 서비스 레이어에서 카테고리별 조회 로직 작성
- 전체 용어 조회
  - 전체 용어 목록 조회 API 구현
  - 서비스 레이어에서 전체 용어 조회 로직 작성
- 용어 CRUD(등록 / 수정 / 삭제)
  - 용어 등록, 수정, 삭제 API 구현
  - 서비스 레이어에서 관련 비즈니스 로직 작성
  
## 🤔 궁금한점

## 📸 ScreenShot
