### PR TITLE
인사이트 카드 기능 구현

### DIFF
--- a/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
+++ b/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
@@ -1,0 +1,74 @@
+package welkit_server.domain.insightcard.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import welkit_server.domain.insightcard.dto.request.InsightCardRequest;
+import welkit_server.domain.insightcard.dto.response.InsightCardResponse;
+import welkit_server.domain.insightcard.service.InsightCardService;
+import welkit_server.global.dto.SuccessResponse;
+import welkit_server.global.exception.message.SuccessMessage;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/cards")
+public class InsightCardController {
+
+    private final InsightCardService insightCardService;
+
+    @Operation(summary = "인물 카드 생성", description = "새로운 인물 카드를 생성합니다")
+    @PostMapping("/person")
+    public ResponseEntity<SuccessResponse<InsightCardResponse>> createInsightPersonCard(@Valid @RequestBody InsightCardRequest createInsightPersonCardRequest) {
+        InsightCardResponse  insightPersonCardResponse = insightCardService.createInsightCard(createInsightPersonCardRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(SuccessResponse.of(SuccessMessage.CREATED_SUCCESS, insightPersonCardResponse));
+    }
+
+    @Operation(summary = "인물 카드 수정", description = "등록되어 있는 인물 카드를 수정합니다")
+    @PatchMapping("/person/{id}")
+    public ResponseEntity<SuccessResponse<InsightCardResponse>> updatInsightPersonCard(
+            @PathVariable("id") Long insightCardId,
+            @Valid @RequestBody InsightCardRequest editInsightPersonCardRequest
+    ) {
+        InsightCardResponse editInsightPersonCardResponse = insightCardService.editInsightCard(insightCardId, editInsightPersonCardRequest);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessMessage.UPDATED_SUCCESS, editInsightPersonCardResponse));
+    }
+
+    @Operation(summary = "인물 카드 삭제", description = "등록되어 있는 인물 카드를 삭제합니다")
+    @DeleteMapping("/person/{id}")
+    public ResponseEntity<SuccessResponse> deleteInsightPersonCard(@PathVariable("id") Long insightPersonCardId) {
+        insightCardService.deleteInsightCard(insightPersonCardId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.DELETED_SUCCESS));
+    }
+
+    @Operation(summary = "업무 카드 생성", description = "새로운 업무 카드를 생성합니다")
+    @PostMapping("/work")
+    public ResponseEntity<SuccessResponse<InsightCardResponse>> createInsightWorkCard(@Valid @RequestBody InsightCardRequest createInsightWorkCardRequest) {
+        InsightCardResponse  insightWorkCardResponse = insightCardService.createInsightCard(createInsightWorkCardRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(SuccessResponse.of(SuccessMessage.CREATED_SUCCESS, insightWorkCardResponse));
+    }
+
+    @Operation(summary = "업무 카드 수정", description = "등록되어 있는 업무 카드를 수정합니다")
+    @PatchMapping("/work/{id}")
+    public ResponseEntity<SuccessResponse<InsightCardResponse>> updateInsightWorkCard(
+            @PathVariable("id") Long insightCardId,
+            @Valid @RequestBody InsightCardRequest editInsightWorkCardRequest
+    ) {
+        InsightCardResponse editInsightWorkCardResponse = insightCardService.editInsightCard(insightCardId, editInsightWorkCardRequest);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessMessage.UPDATED_SUCCESS, editInsightWorkCardResponse));
+    }
+
+    @Operation(summary = "업무 카드 삭제", description = "등록되어 있는 업무 카드를 삭제합니다")
+    @DeleteMapping("/work/{id}")
+    public ResponseEntity<SuccessResponse> deleteInsightWorkCard(@PathVariable("id") Long insightWorkCardId) {
+        insightCardService.deleteInsightCard(insightWorkCardId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.DELETED_SUCCESS));
+    }
+
+}

--- a/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
+++ b/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
@@ -7,10 +7,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import welkit_server.domain.insightcard.dto.request.InsightCardRequest;
+import welkit_server.domain.insightcard.dto.response.GetAllInsightCardResponse;
 import welkit_server.domain.insightcard.dto.response.InsightCardResponse;
 import welkit_server.domain.insightcard.service.InsightCardService;
 import welkit_server.global.dto.SuccessResponse;
 import welkit_server.global.exception.message.SuccessMessage;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +21,20 @@ import welkit_server.global.exception.message.SuccessMessage;
 public class InsightCardController {
 
     private final InsightCardService insightCardService;
+
+    @Operation(summary = "인물 카드 전체 조회", description = "등록된 인물 카드를 전체 조회합니다")
+    @GetMapping("/person")
+    public ResponseEntity<SuccessResponse<GetAllInsightCardResponse>> getAllInsightPersonCard() {
+        List<GetAllInsightCardResponse> insightPersonCards = insightCardService.getAllInsightCards();
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, insightPersonCards));
+    }
+
+    @Operation(summary = "인물 카드 상세 조회", description = "등록된 인물 카드 중 선택한 인물 카드를 조회합니다")
+    @GetMapping("/person/{id}")
+    public ResponseEntity<SuccessResponse<InsightCardResponse>> getInsightPersonCardByCardNumber(@PathVariable("id") Long insightPersonCardId) {
+        InsightCardResponse insighPersonCard = insightCardService.getInsightCardById(insightPersonCardId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, insighPersonCard));
+    }
 
     @Operation(summary = "인물 카드 생성", description = "새로운 인물 카드를 생성합니다")
     @PostMapping("/person")
@@ -43,6 +60,20 @@ public class InsightCardController {
     public ResponseEntity<SuccessResponse> deleteInsightPersonCard(@PathVariable("id") Long insightPersonCardId) {
         insightCardService.deleteInsightCard(insightPersonCardId);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.DELETED_SUCCESS));
+    }
+
+    @Operation(summary = "업무 카드 전체 조회", description = "등록된 업무 카드를 전체 조회합니다")
+    @GetMapping("/work")
+    public ResponseEntity<SuccessResponse<GetAllInsightCardResponse>> getAllInsightWorkCard() {
+        List<GetAllInsightCardResponse> insightWorkCards = insightCardService.getAllInsightCards();
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, insightWorkCards));
+    }
+
+    @Operation(summary = "업무 카드 상세 조회", description = "등록된 업무 카드 중 선택한 업무 카드를 조회합니다")
+    @GetMapping("/work/{id}")
+    public ResponseEntity<SuccessResponse<InsightCardResponse>> getInsightWorkCardByCardNumber(@PathVariable("id") Long insightWorkCardId) {
+        InsightCardResponse insighWorkCard = insightCardService.getInsightCardById(insightWorkCardId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, insighWorkCard));
     }
 
     @Operation(summary = "업무 카드 생성", description = "새로운 업무 카드를 생성합니다")

--- a/src/main/java/welkit_server/domain/insightcard/dto/request/InsightCardRequest.java
+++ b/src/main/java/welkit_server/domain/insightcard/dto/request/InsightCardRequest.java
@@ -1,0 +1,32 @@
+package welkit_server.domain.insightcard.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+import welkit_server.domain.insightcard.entity.InsightCard;
+import welkit_server.domain.insightcard.model.CardType;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class InsightCardRequest {
+
+    @NotBlank
+    private String title;
+    @NotBlank
+    private String description;
+    private String note;
+    @NotNull
+    private CardType type;
+    private Boolean isFavorite;
+
+    public InsightCard toEntity() {
+        return InsightCard.builder()
+                .title(title != null ? title.trim() : null)
+                .description(description != null ? description.trim() : null)
+                .note(note != null ? note.trim() : null)
+                .type(type)
+                .isFavorite(isFavorite)
+                .build();
+    }
+
+}

--- a/src/main/java/welkit_server/domain/insightcard/dto/response/GetAllInsightCardResponse.java
+++ b/src/main/java/welkit_server/domain/insightcard/dto/response/GetAllInsightCardResponse.java
@@ -1,0 +1,22 @@
+package welkit_server.domain.insightcard.dto.response;
+
+import lombok.*;
+import welkit_server.domain.insightcard.model.CardType;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class GetAllInsightCardResponse {
+
+    private Long insightCardId;
+    private String title;
+    private String description;
+    private String note;
+    private CardType type;
+    private boolean isFavorite;
+    private LocalDateTime lastViewedAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/welkit_server/domain/insightcard/dto/response/InsightCardResponse.java
+++ b/src/main/java/welkit_server/domain/insightcard/dto/response/InsightCardResponse.java
@@ -1,0 +1,31 @@
+package welkit_server.domain.insightcard.dto.response;
+
+import lombok.*;
+import welkit_server.domain.insightcard.entity.InsightCard;
+import welkit_server.domain.insightcard.model.CardType;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class InsightCardResponse {
+
+    private Long insightCardId;
+    private String title;
+    private String description;
+    private String note;
+    private CardType type;
+    private boolean isFavorite;
+
+    public static InsightCardResponse fromEntity(InsightCard insightCard) {
+        return InsightCardResponse.builder()
+                .insightCardId(insightCard.getId())
+                .title(insightCard.getTitle())
+                .description(insightCard.getDescription())
+                .note(insightCard.getNote())
+                .type(insightCard.getType())
+                .isFavorite(insightCard.isFavorite())
+                .build();
+    }
+
+}

--- a/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
+++ b/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
@@ -2,6 +2,7 @@ package welkit_server.domain.insightcard.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import welkit_server.domain.insightcard.dto.request.InsightCardRequest;
 import welkit_server.domain.insightcard.model.CardType;
 import welkit_server.domain.user.entity.User;
 import welkit_server.global.domain.BaseEntity;
@@ -30,21 +31,39 @@ public class InsightCard extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 25)
-    private CardType cardType;
+    private CardType type;
 
     @Column(name = "is_favorite", nullable = false)
     @Builder.Default
     private boolean isFavorite = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id") //nullable = false
     private User user;
 
-    @Column(name = "last_viewed_at", nullable = false)
+    @Column(name = "last_viewed_at") //nullable = false
     private LocalDateTime lastViewedAt;
 
     public void updateLastViewedAt() {
         this.lastViewedAt = LocalDateTime.now();
+    }
+
+    public void editInsightCard(InsightCardRequest request) {
+        if (request.getTitle() != null) {
+            this.title = request.getTitle().trim();
+        }
+        if (request.getDescription() != null) {
+            this.description = request.getDescription().trim();
+        }
+        if (request.getNote() != null) {
+            this.note = request.getNote().trim();
+        }
+        if (request.getType() != null) {
+            this.type = request.getType();
+        }
+        if (request.getIsFavorite() != null) {
+            this.isFavorite = request.getIsFavorite();
+        }
     }
 
 }

--- a/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
+++ b/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
@@ -1,0 +1,16 @@
+package welkit_server.domain.insightcard.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import welkit_server.domain.insightcard.entity.InsightCard;
+
+import java.util.List;
+
+@Repository
+public interface InsightCardRepository extends JpaRepository<InsightCard, Long> {
+
+    @Query("SELECT i FROM InsightCard i ORDER BY i.lastModifiedDate DESC")
+    List<InsightCard> findAllInsightCards();
+
+}

--- a/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
+++ b/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import welkit_server.domain.insightcard.entity.InsightCard;
-
 import java.util.List;
 
 @Repository

--- a/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
+++ b/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
@@ -1,0 +1,44 @@
+package welkit_server.domain.insightcard.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import welkit_server.domain.insightcard.dto.request.InsightCardRequest;
+import welkit_server.domain.insightcard.dto.response.InsightCardResponse;
+import welkit_server.domain.insightcard.entity.InsightCard;
+import welkit_server.domain.insightcard.repository.InsightCardRepository;
+import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.NotFoundException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+
+public class InsightCardService {
+
+    private final InsightCardRepository insightCardRepository;
+
+    @Transactional
+    public InsightCardResponse createInsightCard(InsightCardRequest createInsightCardRequest) {
+        InsightCard insightCard = insightCardRepository.save(createInsightCardRequest.toEntity());
+        return InsightCardResponse.fromEntity(insightCard);
+    }
+
+    @Transactional
+    public InsightCardResponse editInsightCard(Long insightCardId, InsightCardRequest editInsightCardRequest) {
+        InsightCard insightCard = findInsightCardById(insightCardId);
+        insightCard.editInsightCard(editInsightCardRequest);
+        return InsightCardResponse.fromEntity(insightCard);
+    }
+
+    @Transactional
+    public void deleteInsightCard(Long insightCardId) {
+        InsightCard insightCard = findInsightCardById(insightCardId);
+        insightCardRepository.delete(insightCard);
+    }
+
+    public InsightCard findInsightCardById(Long insightCardId) {
+        return insightCardRepository.findById(insightCardId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.INSIGHT_CARD_NOT_FOUND));
+    }
+}

--- a/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
+++ b/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
@@ -4,11 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.insightcard.dto.request.InsightCardRequest;
+import welkit_server.domain.insightcard.dto.response.GetAllInsightCardResponse;
 import welkit_server.domain.insightcard.dto.response.InsightCardResponse;
 import welkit_server.domain.insightcard.entity.InsightCard;
 import welkit_server.domain.insightcard.repository.InsightCardRepository;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.NotFoundException;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +20,28 @@ import welkit_server.global.exception.model.NotFoundException;
 public class InsightCardService {
 
     private final InsightCardRepository insightCardRepository;
+
+    public List<GetAllInsightCardResponse> getAllInsightCards() {
+        List<InsightCard> insightCards = insightCardRepository.findAll();
+        return insightCards.stream()
+                .map(insightCard -> GetAllInsightCardResponse.builder()
+                        .insightCardId(insightCard.getId())
+                        .title(insightCard.getTitle())
+                        .description(insightCard.getDescription())
+                        .note(insightCard.getNote())
+                        .type(insightCard.getType())
+                        .lastViewedAt(insightCard.getLastViewedAt())
+                        .updatedAt(insightCard.getLastModifiedDate())
+                        .build())
+                .toList();
+    }
+
+    @Transactional
+    public InsightCardResponse getInsightCardById(Long insightCardId) {
+        InsightCard insightCard = findInsightCardById(insightCardId);
+        insightCard.updateLastViewedAt();
+        return InsightCardResponse.fromEntity(insightCard);
+    }
 
     @Transactional
     public InsightCardResponse createInsightCard(InsightCardRequest createInsightCardRequest) {
@@ -41,4 +66,5 @@ public class InsightCardService {
         return insightCardRepository.findById(insightCardId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.INSIGHT_CARD_NOT_FOUND));
     }
+
 }

--- a/src/main/java/welkit_server/domain/terms/controller/TermController.java
+++ b/src/main/java/welkit_server/domain/terms/controller/TermController.java
@@ -62,7 +62,7 @@ public class TermController {
     @DeleteMapping("/{id}")
     public ResponseEntity<SuccessResponse> deleteTerm(@PathVariable("id") Long termId){
         termService.deleteTerm(termId);
-        return new ResponseEntity<>(SuccessResponse.of(SuccessMessage.DELETED_SUCCESS), HttpStatus.NO_CONTENT);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.DELETED_SUCCESS));
     }
 
 }

--- a/src/main/java/welkit_server/domain/terms/dto/response/CreateTermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/CreateTermResponse.java
@@ -1,6 +1,7 @@
 package welkit_server.domain.terms.dto.response;
 
 import lombok.*;
+import welkit_server.domain.terms.entity.Term;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -14,8 +15,14 @@ public class CreateTermResponse {
     private Long categoryId;
     private String categoryName;
 
-    public static CreateTermResponse of(Long termId, String name, String definition, Long categoryId, String categoryName) {
-        return new CreateTermResponse(termId, name, definition, categoryId, categoryName);
+    public static CreateTermResponse fromEntity(Term term) {
+        return CreateTermResponse.builder()
+                .termId(term.getId())
+                .name(term.getName())
+                .definition(term.getDefinition())
+                .categoryId(term.getCategory().getId())
+                .categoryName(term.getCategory().getName())
+                .build();
     }
 
 }

--- a/src/main/java/welkit_server/domain/terms/dto/response/EditTermResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/EditTermResponse.java
@@ -1,6 +1,7 @@
 package welkit_server.domain.terms.dto.response;
 
 import lombok.*;
+import welkit_server.domain.terms.entity.Term;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -13,8 +14,13 @@ public class EditTermResponse {
     private String definition;
     private Long categoryId;
 
-    public static EditTermResponse of(Long termId, String name, String definition, Long categoryId) {
-        return new EditTermResponse(termId, name, definition, categoryId);
+    public static EditTermResponse fromEntity(Term term) {
+        return EditTermResponse.builder()
+                .termId(term.getId())
+                .name(term.getName())
+                .definition(term.getDefinition())
+                .categoryId(term.getCategory().getId())
+                .build();
     }
 
 }

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -59,13 +59,7 @@ public class TermService {
     public CreateTermResponse createTerm(CreateTermRequest createTermRequest) {
         TermCategory category = termCategoryService.findOrCreate(createTermRequest.getCategoryId(), createTermRequest.getCategoryName());
         Term term = termRepository.save(createTermRequest.toEntity(category));
-        return CreateTermResponse.of(
-                term.getId(),
-                term.getName(),
-                term.getDefinition(),
-                category.getId(),
-                category.getName()
-        );
+        return CreateTermResponse.fromEntity(term);
     }
 
     @Transactional
@@ -73,12 +67,7 @@ public class TermService {
         Term term = getTermById(termId);
         TermCategory category = termCategoryService.findOrCreate(editTermRequest.getCategoryId(), editTermRequest.getCategoryName());
         term.editTerm(editTermRequest, category);
-        return EditTermResponse.of(
-                term.getId(),
-                term.getName(),
-                term.getDefinition(),
-                term.getCategory().getId()
-        );
+        return EditTermResponse.fromEntity(term);
     }
 
     @Transactional


### PR DESCRIPTION
## 🔥 Related Issues
- #14 

## ✅ 작업 리스트
- [x] 인사이트 카드 생성 /수정/ 삭제 로직 구현
- [x] 인사이트 카드 전체 조회 / 상세 조회 로직 구현
- [x] 	DTO 및 Service 리팩토링 (fromEntity 패턴 적용)

## 🔧 작업 내용
- 인물 카드(person)와 업무 카드(work) CRUD 기능 구현
- Service에서 DTO 변환 로직을 fromEntity 정적 메서드로 통일하여 가독성 및 재사용성 향상
- 조회 시 마지막 조회 시간(lastViewedAt) 업데이트 기능 적용
- Term 관련 DTO/Service 리팩토링 (of → fromEntity)


## 🤔 궁금한점

## 📸 ScreenShot
