### PR TITLE
마이페이지 기능 구현

### DIFF
--- a/src/main/java/welkit_server/domain/admin/entity/Notice.java
+++ b/src/main/java/welkit_server/domain/admin/entity/Notice.java
@@ -1,8 +1,8 @@
-package welkit_server.domain.mypage.entity;
+package welkit_server.domain.admin.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import welkit_server.domain.mypage.model.NoticePriority;
+import welkit_server.domain.admin.model.NoticePriority;
 import welkit_server.global.domain.BaseEntity;
 
 @Entity

--- a/src/main/java/welkit_server/domain/admin/model/NoticePriority.java
+++ b/src/main/java/welkit_server/domain/admin/model/NoticePriority.java
@@ -1,4 +1,4 @@
-package welkit_server.domain.mypage.model;
+package welkit_server.domain.admin.model;
 
 public enum NoticePriority {
     LOW,

--- a/src/main/java/welkit_server/domain/auth/signup/company/service/CompanySignupService.java
+++ b/src/main/java/welkit_server/domain/auth/signup/company/service/CompanySignupService.java
@@ -3,7 +3,11 @@ package welkit_server.domain.auth.signup.company.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.auth.signup.company.dto.SignupRequest;
+import welkit_server.domain.mypage.entity.LockSetting;
+import welkit_server.domain.mypage.model.FeatureName;
+import welkit_server.domain.mypage.repository.LockSettingRepository;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.model.EmailType;
 import welkit_server.domain.user.repository.UserRepository;
@@ -11,7 +15,7 @@ import welkit_server.global.config.BlockedDomainsConfig;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.BadRequestException;
 import welkit_server.global.redis.RedisUtil;
-
+import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -19,10 +23,12 @@ import java.util.List;
 public class CompanySignupService {
 
     private final UserRepository userRepository;
+    private final LockSettingRepository lockSettingRepository;
     private final RedisUtil redisUtil;
     private final PasswordEncoder passwordEncoder;
     private final BlockedDomainsConfig blockedDomainsConfig;
 
+    @Transactional
     public void signup(SignupRequest request) {
         String email = request.getEmail();
 
@@ -49,6 +55,17 @@ public class CompanySignupService {
                 .build();
 
         userRepository.save(user);
+
+        List<LockSetting> lockSettings = Arrays.stream(FeatureName.values())
+                        .map(feature -> LockSetting.builder()
+                                .user(user)
+                                .featureName(feature)
+                                .isLocked(false)
+                                .build())
+                       .toList();
+
+        lockSettingRepository.saveAll(lockSettings);
+
         redisUtil.deleteEmailCode(email);
     }
 

--- a/src/main/java/welkit_server/domain/auth/signup/google/service/GoogleSignupService.java
+++ b/src/main/java/welkit_server/domain/auth/signup/google/service/GoogleSignupService.java
@@ -7,16 +7,22 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import welkit_server.domain.auth.signup.google.dto.GoogleSignupRequest;
+import welkit_server.domain.mypage.entity.LockSetting;
+import welkit_server.domain.mypage.model.FeatureName;
+import welkit_server.domain.mypage.repository.LockSettingRepository;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.model.EmailType;
 import welkit_server.domain.user.model.JobRole;
 import welkit_server.domain.user.repository.UserRepository;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.BadRequestException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -24,6 +30,7 @@ import java.util.Map;
 public class GoogleSignupService {
 
     private final UserRepository userRepository;
+    private final LockSettingRepository lockSettingRepository;
     private final PasswordEncoder passwordEncoder;
     private final RestTemplate restTemplate = new RestTemplate();
 
@@ -95,6 +102,7 @@ public class GoogleSignupService {
     }
 
     // DB 저장
+    @Transactional
     public void signup(String email, String password, JobRole jobRole) {
         if (userRepository.existsByGoogleEmail(email)) {
             throw new BadRequestException(ErrorMessage.DUPLICATE_EMAIL);
@@ -111,6 +119,16 @@ public class GoogleSignupService {
                 .build();
 
         userRepository.save(user);
+
+        List<LockSetting> lockSettings = Arrays.stream(FeatureName.values())
+                .map(feature -> LockSetting.builder()
+                        .user(user)
+                        .featureName(feature)
+                        .isLocked(false)
+                        .build())
+                .toList();
+
+        lockSettingRepository.saveAll(lockSettings);
     }
 
 }

--- a/src/main/java/welkit_server/domain/auth/signup/personal/service/PersonalSignupService.java
+++ b/src/main/java/welkit_server/domain/auth/signup/personal/service/PersonalSignupService.java
@@ -3,13 +3,19 @@ package welkit_server.domain.auth.signup.personal.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.auth.signup.personal.dto.SignupRequest;
+import welkit_server.domain.mypage.entity.LockSetting;
+import welkit_server.domain.mypage.model.FeatureName;
+import welkit_server.domain.mypage.repository.LockSettingRepository;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.model.EmailType;
 import welkit_server.domain.user.repository.UserRepository;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.BadRequestException;
 import welkit_server.global.redis.RedisUtil;
+import java.util.Arrays;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,7 +24,9 @@ public class PersonalSignupService {
     private final UserRepository userRepository;
     private final RedisUtil redisUtil;
     private final PasswordEncoder passwordEncoder;
+    private final LockSettingRepository lockSettingRepository;
 
+    @Transactional
     public void signup(SignupRequest request) {
         String email = request.getEmail();
 
@@ -41,6 +49,17 @@ public class PersonalSignupService {
                 .build();
 
         userRepository.save(user);
+
+        List<LockSetting> lockSettings = Arrays.stream(FeatureName.values())
+                .map(feature -> LockSetting.builder()
+                        .user(user)
+                        .featureName(feature)
+                        .isLocked(false)
+                        .build())
+                .toList();
+
+        lockSettingRepository.saveAll(lockSettings);
+
         redisUtil.deleteEmailCode(email);
     }
 }

--- a/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
+++ b/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
@@ -27,9 +27,9 @@ public class InsightCardService {
     private final UserRepository userRepository;
 
     public List<GetAllInsightCardResponse> getAllInsightPersonCards(Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User currentUser = getAuthenticatedUser(authentication);
 
-        List<InsightCard> insightCards = insightCardRepository.findAllInsightPersonCards(user);
+        List<InsightCard> insightCards = insightCardRepository.findAllInsightPersonCards(currentUser);
 
         return insightCards.stream()
                 .map(insightCard -> GetAllInsightCardResponse.builder()
@@ -46,9 +46,9 @@ public class InsightCardService {
     }
 
     public List<GetAllInsightCardResponse> getAllInsightWorkCards(Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User currentUser = getAuthenticatedUser(authentication);
 
-        List<InsightCard> insightCards = insightCardRepository.findAllInsightWorkCards(user);
+        List<InsightCard> insightCards = insightCardRepository.findAllInsightWorkCards(currentUser);
 
         return insightCards.stream()
                 .map(insightCard -> GetAllInsightCardResponse.builder()
@@ -66,9 +66,9 @@ public class InsightCardService {
 
     @Transactional
     public InsightCardResponse getInsightCardById(Long cardId,Authentication authentication) {
-        Long userId = getAuthenticatedUserId(authentication);
+        User currentUser = getAuthenticatedUser(authentication);
 
-        InsightCard insightCard = findOwnedInsightCard(userId, cardId);
+        InsightCard insightCard = findOwnedInsightCard(currentUser.getId(), cardId);
         insightCard.updateLastViewedAt();
 
         return InsightCardResponse.fromEntity(insightCard);
@@ -76,10 +76,10 @@ public class InsightCardService {
 
     @Transactional
     public InsightCardResponse createInsightCard(InsightCardRequest createInsightCardRequest,Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User currentUser = getAuthenticatedUser(authentication);
 
         InsightCard insightCard = createInsightCardRequest.toEntity();
-        insightCard.setUser(user);
+        insightCard.setUser(currentUser);
         insightCard.updateUpdatedAt();
 
         insightCardRepository.save(insightCard);
@@ -89,9 +89,9 @@ public class InsightCardService {
 
     @Transactional
     public InsightCardResponse editInsightCard(Long cardId, InsightCardRequest editInsightCardRequest, Authentication authentication) {
-        Long userId = getAuthenticatedUserId(authentication);
+        User currentUser = getAuthenticatedUser(authentication);
 
-        InsightCard insightCard = findOwnedInsightCard(userId, cardId);
+        InsightCard insightCard = findOwnedInsightCard(currentUser.getId(), cardId);
         insightCard.editInsightCard(editInsightCardRequest);
         insightCard.updateUpdatedAt();
 
@@ -100,9 +100,9 @@ public class InsightCardService {
 
     @Transactional
     public void deleteInsightCard(Long cardId, Authentication authentication) {
-        Long userId = getAuthenticatedUserId(authentication);
+        User currentUser = getAuthenticatedUser(authentication);
 
-        InsightCard insightCard = findOwnedInsightCard(userId, cardId);
+        InsightCard insightCard = findOwnedInsightCard(currentUser.getId(), cardId);
 
         insightCardRepository.delete(insightCard);
     }

--- a/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
+++ b/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
@@ -132,6 +132,5 @@ public class InsightCardService {
         validateOwnership(userId, insightCard);
         return insightCard;
     }
-
-
+    
 }

--- a/src/main/java/welkit_server/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/welkit_server/domain/mypage/controller/MyPageController.java
@@ -1,0 +1,43 @@
+package welkit_server.domain.mypage.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import welkit_server.domain.mypage.dto.request.FeatureLockSettingRequest;
+import welkit_server.domain.mypage.dto.request.LockSettingRequest;
+import welkit_server.domain.mypage.dto.response.FeatureLockSettingResponse;
+import welkit_server.domain.mypage.service.MyPageService;
+import welkit_server.global.dto.SuccessResponse;
+import welkit_server.global.exception.message.SuccessMessage;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mypage")
+public class MyPageController {
+
+    private final MyPageService mypageService;
+
+    @Operation(summary = "암호 생성", description = "기능별 암호 설정을 위한 암호를 생성합니다")
+    @PutMapping("/lock/pin")
+    public ResponseEntity<SuccessResponse<?>> lockPin(
+            @Valid @RequestBody LockSettingRequest lockSettingRequest,
+            Authentication authentication
+    ) {
+        mypageService.setLock(lockSettingRequest,authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.CREATED_SUCCESS));
+    }
+
+    @Operation(summary = "기능별 암호 설정", description = "기능별 암호 설정을 합니다")
+    @PatchMapping("/lock")
+    public ResponseEntity<SuccessResponse<FeatureLockSettingResponse>> settingFeatureLock(
+            @Valid @RequestBody FeatureLockSettingRequest featureLockSettingRequest,
+            Authentication authentication
+    ) {
+        FeatureLockSettingResponse featureLockSettingResponse = mypageService.setFeatureLock(featureLockSettingRequest, authentication);
+        String msg = SuccessMessage.LOCK_FEATURE_UPDATED.formatMessage(featureLockSettingRequest.getFeatureName());
+        return ResponseEntity.ok(SuccessResponse.of(featureLockSettingResponse, msg, SuccessMessage.LOCK_FEATURE_UPDATED.getStatus()));
+    }
+}

--- a/src/main/java/welkit_server/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/welkit_server/domain/mypage/controller/MyPageController.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import welkit_server.domain.mypage.dto.request.FeatureLockSettingRequest;
 import welkit_server.domain.mypage.dto.request.LockSettingRequest;
+import welkit_server.domain.mypage.dto.request.SolveLockRequest;
 import welkit_server.domain.mypage.dto.response.FeatureLockSettingResponse;
 import welkit_server.domain.mypage.service.MyPageService;
 import welkit_server.global.dto.SuccessResponse;
@@ -19,6 +20,7 @@ import welkit_server.global.exception.message.SuccessMessage;
 public class MyPageController {
 
     private final MyPageService mypageService;
+
 
     @Operation(summary = "암호 생성", description = "기능별 암호 설정을 위한 암호를 생성합니다")
     @PutMapping("/lock/pin")
@@ -38,6 +40,24 @@ public class MyPageController {
     ) {
         FeatureLockSettingResponse featureLockSettingResponse = mypageService.setFeatureLock(featureLockSettingRequest, authentication);
         String msg = SuccessMessage.LOCK_FEATURE_UPDATED.formatMessage(featureLockSettingRequest.getFeatureName());
-        return ResponseEntity.ok(SuccessResponse.of(featureLockSettingResponse, msg, SuccessMessage.LOCK_FEATURE_UPDATED.getStatus()));
+        return ResponseEntity.ok(
+                SuccessResponse.of(SuccessMessage.LOCK_FEATURE_UPDATED.getStatus(), msg, featureLockSettingResponse )
+        );
     }
+
+    @Operation(summary = "기능별 암호 검증", description = "사용자가 해당 기능을 이용하기위해 입력한 암호를 검증합니다")
+    @PostMapping("/lock/verify")
+    public ResponseEntity<SuccessResponse<Void>> verifyFeatureLock(
+            @Valid @RequestBody SolveLockRequest solveLockRequest,
+            Authentication authentication
+    ) {
+        mypageService.solveFeatureLock(solveLockRequest, authentication);
+
+        String formattedMsg = SuccessMessage.LOCK_SOLVE_SUCCESS.formatMessage(solveLockRequest.getFeatureName());
+
+        return ResponseEntity.ok(
+                SuccessResponse.of(SuccessMessage.LOCK_SOLVE_SUCCESS.getStatus(), formattedMsg, null)
+        );
+    }
+
 }

--- a/src/main/java/welkit_server/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/welkit_server/domain/mypage/controller/MyPageController.java
@@ -3,9 +3,13 @@ package welkit_server.domain.mypage.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import welkit_server.domain.mail.dto.request.EmailPostRequest;
+import welkit_server.domain.mail.dto.request.EmailVerifyRequest;
+import welkit_server.domain.mail.dto.response.EmailResponse;
 import welkit_server.domain.mypage.dto.request.FeatureLockSettingRequest;
 import welkit_server.domain.mypage.dto.request.LockSettingRequest;
 import welkit_server.domain.mypage.dto.request.SolveLockRequest;
@@ -21,7 +25,6 @@ public class MyPageController {
 
     private final MyPageService mypageService;
 
-
     @Operation(summary = "암호 생성", description = "기능별 암호 설정을 위한 암호를 생성합니다")
     @PutMapping("/lock/pin")
     public ResponseEntity<SuccessResponse<?>> lockPin(
@@ -32,7 +35,7 @@ public class MyPageController {
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.CREATED_SUCCESS));
     }
 
-    @Operation(summary = "기능별 암호 설정", description = "기능별 암호 설정을 합니다")
+    @Operation(summary = "기능별 암호 설정", description = "특정 기능을 잠그거나 잠금 해제합니다")
     @PatchMapping("/lock")
     public ResponseEntity<SuccessResponse<FeatureLockSettingResponse>> settingFeatureLock(
             @Valid @RequestBody FeatureLockSettingRequest featureLockSettingRequest,
@@ -58,6 +61,30 @@ public class MyPageController {
         return ResponseEntity.ok(
                 SuccessResponse.of(SuccessMessage.LOCK_SOLVE_SUCCESS.getStatus(), formattedMsg, null)
         );
+    }
+
+    @Operation( summary = "회사 이메일 인증번호 요청", description = "개인 이메일로 인증한 사용자가 회사 이메일로 재인증을 하기 위해 인증번호를 요청합니다")
+    @PostMapping("/email/verify/company")
+    public ResponseEntity<SuccessResponse<EmailResponse>> sendCompanyMail(
+            @Valid @RequestBody EmailPostRequest emailPostRequest,
+            Authentication authentication
+    ) {
+        EmailResponse response = mypageService. sendCompanyVerificationEmail(emailPostRequest, authentication);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessMessage.COMPANY_EMAIL_SEND_SUCCESS, response));
+    }
+
+    @Operation(summary = "회사 이메일 인증번호 검증", description = "개인 이메일 인증 사용자가 회사 이메일로 재인증하기 위해 인증번호를 검증합니다")
+    @PatchMapping("/email/verify/company")
+    public ResponseEntity<SuccessResponse<Void>> verifyCompanyMail(
+            @Valid @RequestBody EmailVerifyRequest emailVerifyRequest,
+            Authentication authentication
+    ) {
+        mypageService.verifyEmail(emailVerifyRequest, authentication);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessMessage.COMPANY_EMAIL_VERIFICATION_SUCCESS, null));
     }
 
 }

--- a/src/main/java/welkit_server/domain/mypage/dto/request/FeatureLockSettingRequest.java
+++ b/src/main/java/welkit_server/domain/mypage/dto/request/FeatureLockSettingRequest.java
@@ -1,0 +1,26 @@
+package welkit_server.domain.mypage.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import welkit_server.domain.mypage.model.FeatureName;
+
+@Getter
+@Builder
+public class FeatureLockSettingRequest {
+
+    @NotNull
+    private final FeatureName featureName;
+
+    @NotNull
+    private final Boolean isLocked;
+
+    @JsonCreator
+    public FeatureLockSettingRequest(
+            @JsonProperty("featureName") FeatureName featureName,
+            @JsonProperty("isLocked") Boolean isLocked) {
+        this.featureName = featureName;
+        this.isLocked = isLocked;
+    }
+}

--- a/src/main/java/welkit_server/domain/mypage/dto/request/LockSettingRequest.java
+++ b/src/main/java/welkit_server/domain/mypage/dto/request/LockSettingRequest.java
@@ -1,13 +1,17 @@
 package welkit_server.domain.mypage.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.*;
 import lombok.*;
+import welkit_server.domain.mypage.model.FeatureName;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 public class LockSettingRequest {
+
+    @NotNull
+    private FeatureName featureName;
 
     @NotBlank
     private String lockPin;

--- a/src/main/java/welkit_server/domain/mypage/dto/request/LockSettingRequest.java
+++ b/src/main/java/welkit_server/domain/mypage/dto/request/LockSettingRequest.java
@@ -1,0 +1,15 @@
+package welkit_server.domain.mypage.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class LockSettingRequest {
+
+    @NotBlank
+    private String lockPin;
+
+}

--- a/src/main/java/welkit_server/domain/mypage/dto/request/SolveLockRequest.java
+++ b/src/main/java/welkit_server/domain/mypage/dto/request/SolveLockRequest.java
@@ -2,12 +2,16 @@ package welkit_server.domain.mypage.dto.request;
 
 import jakarta.validation.constraints.*;
 import lombok.*;
+import welkit_server.domain.mypage.model.FeatureName;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class LockSettingRequest {
+public class SolveLockRequest {
+
+    @NotNull
+    private FeatureName featureName;
 
     @NotBlank
     private String lockPin;

--- a/src/main/java/welkit_server/domain/mypage/dto/response/FeatureLockSettingResponse.java
+++ b/src/main/java/welkit_server/domain/mypage/dto/response/FeatureLockSettingResponse.java
@@ -1,0 +1,22 @@
+package welkit_server.domain.mypage.dto.response;
+
+import lombok.*;
+import welkit_server.domain.mypage.entity.LockSetting;
+import welkit_server.domain.mypage.model.FeatureName;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class FeatureLockSettingResponse {
+
+    private FeatureName featureName;
+    private boolean isLocked;
+
+    public static FeatureLockSettingResponse fromEntity(LockSetting lockSetting) {
+        return FeatureLockSettingResponse.builder()
+                .featureName(lockSetting.getFeatureName())
+                .isLocked(lockSetting.isLocked())
+                .build();
+    }
+}

--- a/src/main/java/welkit_server/domain/mypage/dto/response/FeatureLockSettingResponse.java
+++ b/src/main/java/welkit_server/domain/mypage/dto/response/FeatureLockSettingResponse.java
@@ -19,4 +19,5 @@ public class FeatureLockSettingResponse {
                 .isLocked(lockSetting.isLocked())
                 .build();
     }
+
 }

--- a/src/main/java/welkit_server/domain/mypage/entity/LockSetting.java
+++ b/src/main/java/welkit_server/domain/mypage/entity/LockSetting.java
@@ -1,8 +1,9 @@
-package welkit_server.domain.user.entity;
+package welkit_server.domain.mypage.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import welkit_server.domain.user.model.FeatureName;
+import welkit_server.domain.user.entity.User;
+import welkit_server.domain.mypage.model.FeatureName;
 import welkit_server.global.domain.BaseEntity;
 
 
@@ -28,5 +29,9 @@ public class LockSetting extends BaseEntity {
 
     @Column(name = "is_locked")
     private boolean isLocked;
+
+    public void settingLock(boolean isLocked) {
+        this.isLocked = isLocked;
+    }
 
 }

--- a/src/main/java/welkit_server/domain/mypage/intercepter/FeatureLockInterceptor.java
+++ b/src/main/java/welkit_server/domain/mypage/intercepter/FeatureLockInterceptor.java
@@ -1,0 +1,56 @@
+package welkit_server.domain.mypage.intercepter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import welkit_server.domain.mypage.entity.LockSetting;
+import welkit_server.domain.mypage.model.FeatureName;
+import welkit_server.domain.mypage.repository.LockSettingRepository;
+import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.ForbiddenException;
+import welkit_server.global.exception.model.UnauthorizedException;
+import welkit_server.global.security.dto.CustomUserDetails;
+
+@Component
+@RequiredArgsConstructor
+public class FeatureLockInterceptor implements HandlerInterceptor {
+
+    private final RedisTemplate<String,String> redisTemplate;
+    private final LockSettingRepository lockSettingRepository;
+
+    private static final String FEATURE_UNLOCK_KEY = "feature-unlocked:%d:%s";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnauthorizedException(ErrorMessage.SESSION_EXPIRED);
+        }
+
+        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        FeatureName feature = FeatureName.fromUrl(request.getRequestURI());
+
+        if (feature == null) {
+            return true;
+        }
+
+        LockSetting lockSetting = lockSettingRepository.findByUserIdAndFeatureName(userId, feature);
+        if (lockSetting == null || !lockSetting.isLocked()) {
+            return true;
+        }
+
+        String key = String.format(FEATURE_UNLOCK_KEY, userId, feature.name());
+        String unlocked = redisTemplate.opsForValue().get(key);
+
+        if ("true".equals(unlocked)) {
+            return true;
+        }
+
+        throw new ForbiddenException(ErrorMessage.MYP_INVALID_LOCK_PIN);
+    }
+}

--- a/src/main/java/welkit_server/domain/mypage/intercepter/FeatureLockInterceptor.java
+++ b/src/main/java/welkit_server/domain/mypage/intercepter/FeatureLockInterceptor.java
@@ -12,7 +12,7 @@ import welkit_server.domain.mypage.entity.LockSetting;
 import welkit_server.domain.mypage.model.FeatureName;
 import welkit_server.domain.mypage.repository.LockSettingRepository;
 import welkit_server.global.exception.message.ErrorMessage;
-import welkit_server.global.exception.model.ForbiddenException;
+import welkit_server.global.exception.model.BadRequestException;
 import welkit_server.global.exception.model.UnauthorizedException;
 import welkit_server.global.security.dto.CustomUserDetails;
 
@@ -51,6 +51,6 @@ public class FeatureLockInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        throw new ForbiddenException(ErrorMessage.MYP_INVALID_LOCK_PIN);
+        throw new BadRequestException(ErrorMessage.MYP_INVALID_LOCK_PIN);
     }
 }

--- a/src/main/java/welkit_server/domain/mypage/model/FeatureName.java
+++ b/src/main/java/welkit_server/domain/mypage/model/FeatureName.java
@@ -1,8 +1,26 @@
 package welkit_server.domain.mypage.model;
+import lombok.Getter;
 
+@Getter
 public enum FeatureName {
-    TERMS,
-    INSIGHT_CARDS,
-    RETROSPECTIVES,
-    COMMUNITY
+    INSIGHT_CARDS("/cards"),
+    TERMS("/terms"),
+    COMMUNITY("/community"),
+    RETROSPECTIVES("/retrospectives");
+
+    private final String pathPrefix;
+
+    FeatureName(String pathPrefix) {
+        this.pathPrefix = pathPrefix;
+    }
+
+    public static FeatureName fromUrl(String uri) {
+        for (FeatureName feature : values()) {
+            if (uri.startsWith(feature.getPathPrefix())) {
+                return feature;
+            }
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/welkit_server/domain/mypage/model/FeatureName.java
+++ b/src/main/java/welkit_server/domain/mypage/model/FeatureName.java
@@ -1,4 +1,4 @@
-package welkit_server.domain.user.model;
+package welkit_server.domain.mypage.model;
 
 public enum FeatureName {
     TERMS,

--- a/src/main/java/welkit_server/domain/mypage/repository/LockSettingRepository.java
+++ b/src/main/java/welkit_server/domain/mypage/repository/LockSettingRepository.java
@@ -10,7 +10,6 @@ import welkit_server.domain.mypage.model.FeatureName;
 @Repository
 public interface LockSettingRepository extends JpaRepository<LockSetting, Long> {
 
-    @Query("SELECT l FROM LockSetting l WHERE l.user.id = :userId AND l.featureName = :featureName")
-    LockSetting findIsLockedByUserIdAndFeatureName(@Param("userId") Long userId, @Param("featureName") FeatureName featureName);
+    LockSetting findByUserIdAndFeatureName(Long userId, FeatureName featureName);
 
 }

--- a/src/main/java/welkit_server/domain/mypage/repository/LockSettingRepository.java
+++ b/src/main/java/welkit_server/domain/mypage/repository/LockSettingRepository.java
@@ -1,0 +1,16 @@
+package welkit_server.domain.mypage.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import welkit_server.domain.mypage.entity.LockSetting;
+import welkit_server.domain.mypage.model.FeatureName;
+
+@Repository
+public interface LockSettingRepository extends JpaRepository<LockSetting, Long> {
+
+    @Query("SELECT l FROM LockSetting l WHERE l.user.id = :userId AND l.featureName = :featureName")
+    LockSetting findIsLockedByUserIdAndFeatureName(@Param("userId") Long userId, @Param("featureName") FeatureName featureName);
+
+}

--- a/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
+++ b/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
@@ -1,0 +1,71 @@
+package welkit_server.domain.mypage.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import welkit_server.domain.mypage.dto.request.FeatureLockSettingRequest;
+import welkit_server.domain.mypage.dto.request.LockSettingRequest;
+import welkit_server.domain.mypage.dto.response.FeatureLockSettingResponse;
+import welkit_server.domain.mypage.entity.LockSetting;
+import welkit_server.domain.mypage.repository.LockSettingRepository;
+import welkit_server.domain.user.entity.User;
+import welkit_server.domain.user.repository.UserRepository;
+import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.BadRequestException;
+import welkit_server.global.exception.model.UnauthorizedException;
+import welkit_server.global.security.dto.CustomUserDetails;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder encoder;
+    private final LockSettingRepository lockSettingRepository;
+
+    //암호 설정
+    @Transactional
+    public void setLock(LockSettingRequest lockSettingRequest, Authentication authentication) {
+        User user = getAuthenticatedUser(authentication);
+        String lockPin = lockSettingRequest.getLockPin();
+
+        if (lockPin == null || lockPin.isEmpty()) {
+            throw new BadRequestException(ErrorMessage.WK_ENUM_VALUE_BAD_REQUEST);
+        }
+
+        user.settingLockPin(encoder.encode(lockPin));
+    }
+    //기능별 암호 설정
+    @Transactional
+    public FeatureLockSettingResponse setFeatureLock(FeatureLockSettingRequest featureLockSettingRequest, Authentication authentication) {
+        User user = getAuthenticatedUser(authentication);
+        Long currentUserId = getAuthenticatedUserId(authentication);
+
+        LockSetting lockSetting = lockSettingRepository.
+                findIsLockedByUserIdAndFeatureName(currentUserId, featureLockSettingRequest.getFeatureName());
+
+        if (user.getLockPin() == null || user.getLockPin().isEmpty()) {
+            throw new BadRequestException(ErrorMessage.MYP_LOCK_PIN_NOT_FOUND);
+        }
+
+        Boolean requestedLock = featureLockSettingRequest.getIsLocked();
+        if (!lockSetting.isLocked() && requestedLock != null && !requestedLock.equals(lockSetting.isLocked())) {
+            lockSetting.settingLock(requestedLock);
+        }
+
+        return FeatureLockSettingResponse.fromEntity(lockSetting);
+    }
+
+    public Long getAuthenticatedUserId(Authentication authentication) {
+        return ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+    }
+
+    public User getAuthenticatedUser(Authentication authentication) {
+        return userRepository.findById(getAuthenticatedUserId(authentication))
+                .orElseThrow(() -> new UnauthorizedException(ErrorMessage.SESSION_EXPIRED));
+    }
+
+}

--- a/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
+++ b/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
@@ -1,21 +1,26 @@
 package welkit_server.domain.mypage.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.mypage.dto.request.FeatureLockSettingRequest;
 import welkit_server.domain.mypage.dto.request.LockSettingRequest;
+import welkit_server.domain.mypage.dto.request.SolveLockRequest;
 import welkit_server.domain.mypage.dto.response.FeatureLockSettingResponse;
 import welkit_server.domain.mypage.entity.LockSetting;
+import welkit_server.domain.mypage.model.FeatureName;
 import welkit_server.domain.mypage.repository.LockSettingRepository;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.repository.UserRepository;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.BadRequestException;
+import welkit_server.global.exception.model.ForbiddenException;
 import welkit_server.global.exception.model.UnauthorizedException;
 import welkit_server.global.security.dto.CustomUserDetails;
+import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor
@@ -25,8 +30,8 @@ public class MyPageService {
     private final UserRepository userRepository;
     private final PasswordEncoder encoder;
     private final LockSettingRepository lockSettingRepository;
+    private final RedisTemplate<String, String> redisTemplate;
 
-    //암호 설정
     @Transactional
     public void setLock(LockSettingRequest lockSettingRequest, Authentication authentication) {
         User user = getAuthenticatedUser(authentication);
@@ -36,27 +41,52 @@ public class MyPageService {
             throw new BadRequestException(ErrorMessage.WK_ENUM_VALUE_BAD_REQUEST);
         }
 
+        if (lockPin.length() != 4) {
+            throw new BadRequestException(ErrorMessage.WK_ENUM_VALUE_BAD_REQUEST);
+        }
+
         user.settingLockPin(encoder.encode(lockPin));
     }
-    //기능별 암호 설정
+
     @Transactional
     public FeatureLockSettingResponse setFeatureLock(FeatureLockSettingRequest featureLockSettingRequest, Authentication authentication) {
         User user = getAuthenticatedUser(authentication);
-        Long currentUserId = getAuthenticatedUserId(authentication);
+        Long userId = user.getId();
+        FeatureName feature = featureLockSettingRequest.getFeatureName();
 
         LockSetting lockSetting = lockSettingRepository.
-                findIsLockedByUserIdAndFeatureName(currentUserId, featureLockSettingRequest.getFeatureName());
+                findByUserIdAndFeatureName(user.getId(), featureLockSettingRequest.getFeatureName());
 
-        if (user.getLockPin() == null || user.getLockPin().isEmpty()) {
+        if (user.getLockPin() == null || user.getLockPin().isEmpty() || lockSetting == null) {
             throw new BadRequestException(ErrorMessage.MYP_LOCK_PIN_NOT_FOUND);
         }
 
         Boolean requestedLock = featureLockSettingRequest.getIsLocked();
-        if (!lockSetting.isLocked() && requestedLock != null && !requestedLock.equals(lockSetting.isLocked())) {
+
+        if (requestedLock != null){
             lockSetting.settingLock(requestedLock);
+
+            if (!requestedLock) {
+                String key = "feature-unlocked:" + userId + ":" + feature.name();
+                redisTemplate.delete(key);
+            }
         }
 
         return FeatureLockSettingResponse.fromEntity(lockSetting);
+    }
+
+    public void solveFeatureLock(SolveLockRequest solveLockRequest, Authentication authentication) {
+        User user = getAuthenticatedUser(authentication);
+        Long userId = user.getId();
+        FeatureName feature = solveLockRequest.getFeatureName();
+
+        if (!encoder.matches(solveLockRequest.getLockPin(), user.getLockPin())) {
+            throw new ForbiddenException(ErrorMessage.MYP_INVALID_LOCK_PIN);
+        }
+
+        String key = "feature-unlocked:" + userId + ":" + feature.name();
+        redisTemplate.opsForValue().set(key, "true", Duration.ofHours(3));
+
     }
 
     public Long getAuthenticatedUserId(Authentication authentication) {

--- a/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
+++ b/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
@@ -6,6 +6,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import welkit_server.domain.mail.dto.request.EmailPostRequest;
+import welkit_server.domain.mail.dto.request.EmailVerifyRequest;
+import welkit_server.domain.mail.dto.response.EmailResponse;
+import welkit_server.domain.mail.service.EmailService;
 import welkit_server.domain.mypage.dto.request.FeatureLockSettingRequest;
 import welkit_server.domain.mypage.dto.request.LockSettingRequest;
 import welkit_server.domain.mypage.dto.request.SolveLockRequest;
@@ -14,13 +18,16 @@ import welkit_server.domain.mypage.entity.LockSetting;
 import welkit_server.domain.mypage.model.FeatureName;
 import welkit_server.domain.mypage.repository.LockSettingRepository;
 import welkit_server.domain.user.entity.User;
+import welkit_server.domain.user.model.EmailType;
 import welkit_server.domain.user.repository.UserRepository;
+import welkit_server.global.config.BlockedDomainsConfig;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.BadRequestException;
-import welkit_server.global.exception.model.ForbiddenException;
 import welkit_server.global.exception.model.UnauthorizedException;
+import welkit_server.global.redis.RedisUtil;
 import welkit_server.global.security.dto.CustomUserDetails;
 import java.time.Duration;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +38,10 @@ public class MyPageService {
     private final PasswordEncoder encoder;
     private final LockSettingRepository lockSettingRepository;
     private final RedisTemplate<String, String> redisTemplate;
+    private final RedisUtil redisUtil;
+    private final EmailService emailService;
+    private final BlockedDomainsConfig blockedDomainsConfig;
+
 
     @Transactional
     public void setLock(LockSettingRequest lockSettingRequest, Authentication authentication) {
@@ -44,7 +55,6 @@ public class MyPageService {
         if (lockPin.length() != 4) {
             throw new BadRequestException(ErrorMessage.WK_ENUM_VALUE_BAD_REQUEST);
         }
-
         user.settingLockPin(encoder.encode(lockPin));
     }
 
@@ -65,13 +75,11 @@ public class MyPageService {
 
         if (requestedLock != null){
             lockSetting.settingLock(requestedLock);
-
             if (!requestedLock) {
                 String key = "feature-unlocked:" + userId + ":" + feature.name();
                 redisTemplate.delete(key);
             }
         }
-
         return FeatureLockSettingResponse.fromEntity(lockSetting);
     }
 
@@ -81,12 +89,44 @@ public class MyPageService {
         FeatureName feature = solveLockRequest.getFeatureName();
 
         if (!encoder.matches(solveLockRequest.getLockPin(), user.getLockPin())) {
-            throw new ForbiddenException(ErrorMessage.MYP_INVALID_LOCK_PIN);
+            throw new BadRequestException(ErrorMessage.MYP_INVALID_LOCK_PIN);
         }
 
         String key = "feature-unlocked:" + userId + ":" + feature.name();
         redisTemplate.opsForValue().set(key, "true", Duration.ofHours(3));
+    }
 
+    public EmailResponse sendCompanyVerificationEmail(EmailPostRequest emailPostRequest, Authentication authentication) {
+        User user = getAuthenticatedUser(authentication);
+
+        if(user.getEmailType() == EmailType.COMPANY_EMAIL){
+            throw new BadRequestException(ErrorMessage.MYP_ALREADY_COMPANY_EMAIL_USER);
+        }
+        return emailService.sendVerificationEmail(emailPostRequest.getEmail(), "회사");
+    }
+
+    @Transactional
+    public void verifyEmail(EmailVerifyRequest emailVerifyRequest, Authentication authentication) {
+
+        User user = getAuthenticatedUser(authentication);
+
+        String email = emailVerifyRequest.getEmail();
+        String code = emailVerifyRequest.getCode();
+
+        emailService.verifyEmail(email, code, "회사" );
+
+        if (!redisUtil.isVerifiedEmail(email)) {
+            throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION);
+        }
+
+        if (userRepository.existsByEmail(email)) {
+            throw new BadRequestException(ErrorMessage.DUPLICATE_EMAIL);
+        }
+
+        if (isBlockedDomain(email)) {
+            throw new BadRequestException(ErrorMessage.USR_EMAIL_COMPANY_DOMAIN_INVALID);
+        }
+        user.setEmailType(EmailType.COMPANY_EMAIL);
     }
 
     public Long getAuthenticatedUserId(Authentication authentication) {
@@ -96,6 +136,14 @@ public class MyPageService {
     public User getAuthenticatedUser(Authentication authentication) {
         return userRepository.findById(getAuthenticatedUserId(authentication))
                 .orElseThrow(() -> new UnauthorizedException(ErrorMessage.SESSION_EXPIRED));
+    }
+
+    private boolean isBlockedDomain(String email) {
+        String domain = email.substring(email.indexOf("@") + 1).toLowerCase();
+        List<String> blockedDomains = blockedDomainsConfig.getEmailDomains();
+        return blockedDomains.stream()
+                .map(String::toLowerCase)
+                .anyMatch(d -> d.equals(domain));
     }
 
 }

--- a/src/main/java/welkit_server/domain/retrospectives/service/RetrospectiveService.java
+++ b/src/main/java/welkit_server/domain/retrospectives/service/RetrospectiveService.java
@@ -56,10 +56,10 @@ public class RetrospectiveService {
 
     @Transactional
     public RetrospectiveResponse createRetrospective(RetrospectiveRequest createRetrospectiveRequest, Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User currentUser = getAuthenticatedUser(authentication);
 
         Retrospective retrospective = createRetrospectiveRequest.toEntity();
-        retrospective.setUser(user);
+        retrospective.setUser(currentUser);
 
         retrospectiveRepository.save(retrospective);
 
@@ -68,9 +68,9 @@ public class RetrospectiveService {
 
     @Transactional
     public RetrospectiveResponse editRetrospective(Long retrospectiveId, RetrospectiveRequest editRetrospectiveRequest, Authentication authentication) {
-        Long userId = getAuthenticatedUserId(authentication);
+        User currentUser = getAuthenticatedUser(authentication);
 
-        Retrospective retrospective  = findOwnedRetrospective(userId, retrospectiveId);
+        Retrospective retrospective  = findOwnedRetrospective(currentUser.getId(), retrospectiveId);
         retrospective.editRetrospective(editRetrospectiveRequest);
 
         return RetrospectiveResponse.fromEntity(retrospective);
@@ -78,9 +78,9 @@ public class RetrospectiveService {
 
     @Transactional
     public void deleteRetrospective(Long retrospectiveId, Authentication authentication) {
-        Long userId = getAuthenticatedUserId(authentication);
+        User currentUser = getAuthenticatedUser(authentication);
 
-        Retrospective retrospective = findOwnedRetrospective(userId,retrospectiveId);
+        Retrospective retrospective = findOwnedRetrospective(currentUser.getId(),retrospectiveId);
 
         retrospectiveRepository.delete(retrospective);
     }

--- a/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
+++ b/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
@@ -1,7 +1,6 @@
 package welkit_server.domain.terms.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import welkit_server.domain.terms.entity.*;
 

--- a/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
+++ b/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
@@ -17,10 +17,8 @@ public class CreateTermRequest {
     @NotBlank
     private String definition;
 
-    @NotNull
     private Long categoryId;
 
-    @NotBlank
     private String categoryName;
 
     public Term toEntity(TermCategory category) {

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -87,9 +87,9 @@ public class TermService {
 
     @Transactional
     public EditTermResponse editTerm(Long termId, EditTermRequest editTermRequest, Authentication authentication) {
-        Long userId = getAuthenticatedUserId(authentication);
+        User currentUser = getAuthenticatedUser(authentication);
 
-        Term term = findOwnedTerm(userId, termId);
+        Term term = findOwnedTerm(currentUser.getId(), termId);
         TermCategory category = termCategoryService.findOrCreate(
                 editTermRequest.getCategoryId(),
                 editTermRequest.getCategoryName(),
@@ -103,9 +103,9 @@ public class TermService {
 
     @Transactional
     public void deleteTerm(Long termId, Authentication authentication) {
-        Long userId = getAuthenticatedUserId(authentication);
+        User currentUser = getAuthenticatedUser(authentication);
 
-        Term term = findOwnedTerm(userId, termId);
+        Term term = findOwnedTerm(currentUser.getId(), termId);
 
         termRepository.delete(term);
     }

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -89,7 +89,7 @@ public class TermService {
     public EditTermResponse editTerm(Long termId, EditTermRequest editTermRequest, Authentication authentication) {
         Long userId = getAuthenticatedUserId(authentication);
 
-        Term term = findOwnedTerm(termId, userId);
+        Term term = findOwnedTerm(userId, termId);
         TermCategory category = termCategoryService.findOrCreate(
                 editTermRequest.getCategoryId(),
                 editTermRequest.getCategoryName(),
@@ -105,7 +105,7 @@ public class TermService {
     public void deleteTerm(Long termId, Authentication authentication) {
         Long userId = getAuthenticatedUserId(authentication);
 
-        Term term = findOwnedTerm(termId, userId);
+        Term term = findOwnedTerm(userId, termId);
 
         termRepository.delete(term);
     }

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -98,7 +98,7 @@ public class TermService {
 
         term.editTerm(editTermRequest, category);
 
-        return EditTermResponse.fromEntity(term);
+        return EditTermResponse.    fromEntity(term);
     }
 
     @Transactional

--- a/src/main/java/welkit_server/domain/user/entity/User.java
+++ b/src/main/java/welkit_server/domain/user/entity/User.java
@@ -56,4 +56,8 @@ public class User extends BaseEntity {
         this.lockPin = lockPin;
     }
 
+    public void setEmailType(EmailType emailType){
+        this.emailType = emailType;
+    }
+
 }

--- a/src/main/java/welkit_server/domain/user/entity/User.java
+++ b/src/main/java/welkit_server/domain/user/entity/User.java
@@ -41,7 +41,7 @@ public class User extends BaseEntity {
     private boolean isCompanyVerified;
 
     //기능 잠금 설정용 비밀번호
-    @Column(name = "lock_pin", length=45)
+    @Column(name = "lock_pin", length=100)
     private String lockPin;
 
     @Builder.Default
@@ -51,6 +51,10 @@ public class User extends BaseEntity {
 
     public String getLoginEmail() {
         return this.email != null ? this.email : this.googleEmail;
+    }
+
+    public void settingLockPin(String lockPin){
+        this.lockPin = lockPin;
     }
 
 }

--- a/src/main/java/welkit_server/domain/user/entity/User.java
+++ b/src/main/java/welkit_server/domain/user/entity/User.java
@@ -19,7 +19,6 @@ public class User extends BaseEntity {
     private Long id;
 
     @Column(unique = true, length = 50)
-
     @Email
     private String email;
 

--- a/src/main/java/welkit_server/global/config/WebConfig.java
+++ b/src/main/java/welkit_server/global/config/WebConfig.java
@@ -1,11 +1,18 @@
 package welkit_server.global.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import welkit_server.domain.mypage.intercepter.FeatureLockInterceptor;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final FeatureLockInterceptor featureLockInterceptor;
+
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -15,6 +22,17 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3600);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(featureLockInterceptor)
+                .addPathPatterns(
+                        "/cards/**",
+                        "/terms/**",
+                        "/community/**",
+                        "/retrospectives/**"
+                );
     }
 
 }

--- a/src/main/java/welkit_server/global/dto/SuccessResponse.java
+++ b/src/main/java/welkit_server/global/dto/SuccessResponse.java
@@ -15,12 +15,8 @@ public record SuccessResponse<T>(
         return new SuccessResponse(successMessage.getStatus(), successMessage.getMessage(), null);
     }
 
-    public static <T> SuccessResponse<T> of(final T data, final String message, final int status) {
+    public static <T> SuccessResponse<T> of(int status, String message, T data) {
         return new SuccessResponse<>(status, message, data);
-    }
-
-    public static <T> SuccessResponse<T> of(final SuccessMessage successMessage, final T data, final String formattedMessage) {
-        return new SuccessResponse(successMessage.getStatus(), formattedMessage, data);
     }
 
 }

--- a/src/main/java/welkit_server/global/dto/SuccessResponse.java
+++ b/src/main/java/welkit_server/global/dto/SuccessResponse.java
@@ -14,4 +14,13 @@ public record SuccessResponse<T>(
     public static SuccessResponse of(final SuccessMessage successMessage) {
         return new SuccessResponse(successMessage.getStatus(), successMessage.getMessage(), null);
     }
+
+    public static <T> SuccessResponse<T> of(final T data, final String message, final int status) {
+        return new SuccessResponse<>(status, message, data);
+    }
+
+    public static <T> SuccessResponse<T> of(final SuccessMessage successMessage, final T data, final String formattedMessage) {
+        return new SuccessResponse(successMessage.getStatus(), formattedMessage, data);
+    }
+
 }

--- a/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
+++ b/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
@@ -47,6 +47,7 @@ public enum ErrorMessage {
     MYP_EXPIRED_EMAIL_CODE(400, "MYP1004", "이메일 인증 코드가 만료되었습니다."),
     MYP_INVALID_DATE_RANGE(400, "MYP1005", "공지 사항의 날짜 범위가 올바르지 않습니다."),
     MYP_LOCK_PIN_NOT_FOUND(400, "MYP1006", "PIN이 설정되어 있지 않아 잠금 기능을 사용할 수 없습니다"),
+    MYP_INVALID_LOCK_PIN(403, "MYP1007","PIN이 올바르지 않습니다."),
 
     // 인증/인가 (AUTH)
     SESSION_EXPIRED(401, "AUTH1001", "세션이 만료되었습니다. 다시 로그인해주세요."),

--- a/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
+++ b/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
@@ -46,6 +46,7 @@ public enum ErrorMessage {
     MYP_INVALID_EMAIL_CODE(400, "MYP1003", "이메일 인증 코드가 올바르지 않습니다."),
     MYP_EXPIRED_EMAIL_CODE(400, "MYP1004", "이메일 인증 코드가 만료되었습니다."),
     MYP_INVALID_DATE_RANGE(400, "MYP1005", "공지 사항의 날짜 범위가 올바르지 않습니다."),
+    MYP_LOCK_PIN_NOT_FOUND(400, "MYP1006", "PIN이 설정되어 있지 않아 잠금 기능을 사용할 수 없습니다"),
 
     // 인증/인가 (AUTH)
     SESSION_EXPIRED(401, "AUTH1001", "세션이 만료되었습니다. 다시 로그인해주세요."),

--- a/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
+++ b/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
@@ -43,11 +43,10 @@ public enum ErrorMessage {
     // 마이페이지 (MYP)
     MYP_NOTICE_NOT_FOUND(404, "MYP1001", "해당 공지를 찾을 수 없습니다."),
     MYP_POST_NOT_FOUND(404, "MYP1002", "해당 게시물을 찾을 수 없습니다."),
-    MYP_INVALID_EMAIL_CODE(400, "MYP1003", "이메일 인증 코드가 올바르지 않습니다."),
-    MYP_EXPIRED_EMAIL_CODE(400, "MYP1004", "이메일 인증 코드가 만료되었습니다."),
-    MYP_INVALID_DATE_RANGE(400, "MYP1005", "공지 사항의 날짜 범위가 올바르지 않습니다."),
-    MYP_LOCK_PIN_NOT_FOUND(400, "MYP1006", "PIN이 설정되어 있지 않아 잠금 기능을 사용할 수 없습니다"),
-    MYP_INVALID_LOCK_PIN(403, "MYP1007","PIN이 올바르지 않습니다."),
+    MYP_INVALID_DATE_RANGE(400, "MYP1003", "공지 사항의 날짜 범위가 올바르지 않습니다."),
+    MYP_LOCK_PIN_NOT_FOUND(400, "MYP1004", "PIN이 설정되어 있지 않아 잠금 기능을 사용할 수 없습니다"),
+    MYP_INVALID_LOCK_PIN(400, "MYP1005","PIN이 올바르지 않습니다."),
+    MYP_ALREADY_COMPANY_EMAIL_USER(400, "MYP1006","이미 회사 이메일로 인증된 사용자입니다."),
 
     // 인증/인가 (AUTH)
     SESSION_EXPIRED(401, "AUTH1001", "세션이 만료되었습니다. 다시 로그인해주세요."),

--- a/src/main/java/welkit_server/global/exception/message/SuccessMessage.java
+++ b/src/main/java/welkit_server/global/exception/message/SuccessMessage.java
@@ -22,6 +22,7 @@ public enum SuccessMessage {
     UPDATED_SUCCESS(HttpStatus.OK.value(), "수정이 완료되었습니다"),
 
     LOCK_FEATURE_UPDATED(HttpStatus.OK.value(), "%s 기능의 잠금 상태가 변경되었습니다"),
+    LOCK_SOLVE_SUCCESS(HttpStatus.OK.value(), "%s 기능 잠금 해제되었습니다"),
 
     /*
     201 Created

--- a/src/main/java/welkit_server/global/exception/message/SuccessMessage.java
+++ b/src/main/java/welkit_server/global/exception/message/SuccessMessage.java
@@ -21,6 +21,8 @@ public enum SuccessMessage {
     LOAD_SUCCESS(HttpStatus.OK.value(),"조회가 완료되었습니다"),
     UPDATED_SUCCESS(HttpStatus.OK.value(), "수정이 완료되었습니다"),
 
+    LOCK_FEATURE_UPDATED(HttpStatus.OK.value(), "%s 기능의 잠금 상태가 변경되었습니다"),
+
     /*
     201 Created
      */
@@ -38,4 +40,9 @@ public enum SuccessMessage {
 
     private final int status;
     private final String message;
+
+    public String formatMessage(Object... args) {
+        return String.format(this.message, args);
+    }
+
 }


### PR DESCRIPTION
## 🔥 Related Issues
- #23 

## ✅ 작업 리스트
- [x] 암호 생성 및 기능별 암호 설정 기능 구현
- [x] 기능별 암호 설정 시 LockPin 존재 여부 검증 로직 추가
- [x] 마이페이지 기능 관련 서비스/컨트롤러 구현

## 🔧 작업 내용
####  기능 잠금 상태에 따라 접근 시 암호 요구 로직
1. 마이페이지에서 암호 설정을 먼저 함 *암호가 설정되어 있지 않은 경우에 진행
2. 암호 설정 후 기능별 잠금 상태를 설정 후,  LockSetting DB에 저장 * 기능별 잠금상태의 기본값은 False로 되어있음
3. ` /mypage/lock/verify` 에서 PIN 입력 -> 성공시,  Redis에 `"feature-unlocked:1:TERMS"` 상태 저장 (TTL 3시간) 
4. Redis에 `"feature-unlocked:1:TERMS"` key가 있으면 잠금 해제 상태로 기능 접근가능
## 🤔 궁금한점

## 📸 ScreenShot
