### PR TITLE
최근 본 인사이트 카드 조회 API 추가

### DIFF
--- a/src/main/java/welkit_server/domain/auth/signup/google/dto/GoogleSignupRequest.java
+++ b/src/main/java/welkit_server/domain/auth/signup/google/dto/GoogleSignupRequest.java
@@ -1,6 +1,5 @@
 package welkit_server.domain.auth.signup.google.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,9 +10,6 @@ import welkit_server.domain.user.model.JobRole;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GoogleSignupRequest {
-
-    @NotBlank
-    private String password;
 
     @NotNull
     private JobRole jobRole;

--- a/src/main/java/welkit_server/domain/auth/signup/google/service/GoogleSignupService.java
+++ b/src/main/java/welkit_server/domain/auth/signup/google/service/GoogleSignupService.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -24,7 +23,6 @@ import java.util.Map;
 public class GoogleSignupService {
 
     private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
     private final RestTemplate restTemplate = new RestTemplate();
 
     @Value("${spring.security.oauth2.client.registration.google.client-id}")
@@ -53,7 +51,7 @@ public class GoogleSignupService {
             throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION);
         }
 
-        signup(email, request.getPassword(), request.getJobRole());
+        signup(email, request.getJobRole());
         session.removeAttribute("googleEmail");
     }
 
@@ -95,7 +93,7 @@ public class GoogleSignupService {
     }
 
     // DB 저장
-    public void signup(String email, String password, JobRole jobRole) {
+    public void signup(String email, JobRole jobRole) {
         if (userRepository.existsByGoogleEmail(email)) {
             throw new BadRequestException(ErrorMessage.DUPLICATE_EMAIL);
         }
@@ -104,7 +102,6 @@ public class GoogleSignupService {
 
         User user = User.builder()
                 .googleEmail(email)
-                .password(passwordEncoder.encode(password))
                 .jobRole(jobRole)
                 .isCompanyVerified(isCompany)
                 .emailType(isCompany ? EmailType.COMPANY_EMAIL : EmailType.PERSONAL_EMAIL)

--- a/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
+++ b/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import welkit_server.domain.insightcard.dto.request.InsightCardRequest;
 import welkit_server.domain.insightcard.dto.response.GetAllInsightCardResponse;
 import welkit_server.domain.insightcard.dto.response.InsightCardResponse;
+import welkit_server.domain.insightcard.model.CardType;
 import welkit_server.domain.insightcard.service.InsightCardService;
 import welkit_server.global.dto.SuccessResponse;
 import welkit_server.global.exception.message.SuccessMessage;
@@ -37,6 +38,13 @@ public class InsightCardController {
     ) {
         InsightCardResponse insighPersonCard = insightCardService.getInsightCardById(insightPersonCardId, authentication);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, insighPersonCard));
+    }
+
+    @Operation(summary = "인물 카드 최근본 카드 조회", description = "등록된 인물 카드 중 최근 본 인물 카드를 조회합니다")
+    @GetMapping("/person/recent")
+    public ResponseEntity<SuccessResponse<GetAllInsightCardResponse>> getRecentInsightPersonCard(Authentication authentication) {
+        List<GetAllInsightCardResponse> recentInsightCard = insightCardService.getTop4LastViewedAtInsightCards(CardType.PERSON, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, recentInsightCard));
     }
 
     @Operation(summary = "인물 카드 생성", description = "새로운 인물 카드를 생성합니다")
@@ -87,6 +95,13 @@ public class InsightCardController {
     ) {
         InsightCardResponse insighWorkCard = insightCardService.getInsightCardById(insightWorkCardId, authentication);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, insighWorkCard));
+    }
+
+    @Operation(summary = "업무 카드 최근본 카드 조회", description = "등록된 업무 카드 중 최근 본 업무 카드를 조회합니다")
+    @GetMapping("/work/recent")
+    public ResponseEntity<SuccessResponse<GetAllInsightCardResponse>> getRecentInsightWorkCard(Authentication authentication) {
+        List<GetAllInsightCardResponse> recentInsightCard = insightCardService.getTop4LastViewedAtInsightCards(CardType.WORK, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, recentInsightCard));
     }
 
     @Operation(summary = "업무 카드 생성", description = "새로운 업무 카드를 생성합니다")

--- a/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
+++ b/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import welkit_server.domain.insightcard.entity.InsightCard;
+import welkit_server.domain.insightcard.model.CardType;
 import welkit_server.domain.user.entity.User;
 import java.util.List;
 
@@ -21,4 +22,5 @@ public interface InsightCardRepository extends JpaRepository<InsightCard, Long> 
             "ORDER BY i.updatedAt DESC")
     List<InsightCard> findAllInsightWorkCards(@Param("user") User user);
 
+    List<InsightCard> findTop4ByUserIdAndTypeAndLastViewedAtIsNotNullOrderByLastViewedAtDesc(Long userId, CardType type);
 }

--- a/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
+++ b/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
@@ -8,6 +8,7 @@ import welkit_server.domain.insightcard.dto.request.InsightCardRequest;
 import welkit_server.domain.insightcard.dto.response.GetAllInsightCardResponse;
 import welkit_server.domain.insightcard.dto.response.InsightCardResponse;
 import welkit_server.domain.insightcard.entity.InsightCard;
+import welkit_server.domain.insightcard.model.CardType;
 import welkit_server.domain.insightcard.repository.InsightCardRepository;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.repository.UserRepository;
@@ -49,6 +50,25 @@ public class InsightCardService {
         User user = getAuthenticatedUser(authentication);
 
         List<InsightCard> insightCards = insightCardRepository.findAllInsightWorkCards(user);
+
+        return insightCards.stream()
+                .map(insightCard -> GetAllInsightCardResponse.builder()
+                        .cardId(insightCard.getId())
+                        .title(insightCard.getTitle())
+                        .description(insightCard.getDescription())
+                        .note(insightCard.getNote())
+                        .type(insightCard.getType())
+                        .favorite(insightCard.isFavorite())
+                        .lastViewedAt(insightCard.getLastViewedAt())
+                        .updatedAt(insightCard.getLastModifiedDate())
+                        .build())
+                .toList();
+    }
+
+    public List<GetAllInsightCardResponse> getTop4LastViewedAtInsightCards(CardType cardType, Authentication authentication) {
+        Long userId = getAuthenticatedUserId(authentication);
+
+        List<InsightCard> insightCards = insightCardRepository.findTop4ByUserIdAndTypeAndLastViewedAtIsNotNullOrderByLastViewedAtDesc(userId,cardType);
 
         return insightCards.stream()
                 .map(insightCard -> GetAllInsightCardResponse.builder()

--- a/src/main/java/welkit_server/domain/user/entity/User.java
+++ b/src/main/java/welkit_server/domain/user/entity/User.java
@@ -30,7 +30,7 @@ public class User extends BaseEntity {
     @Column(name = "google_email", length = 50)
     private String googleEmail;
 
-    @Column(nullable = false)
+    @Column
     private String password;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## 🔥 Related Issues
- close #25 

## ✅ 작업 리스트
- [x] 최근 본 인사이트 카드 조회 API 추가
- [x] Google 회원가입 시 비밀번호 미사용 처리

## 🔧 작업 내용
- 사용자별 lastViewedAt 기준 상위 4개 인사이트 카드 조회 API 구현
- lastViewdAt이 Null 인 경우 빈 리스트로 반환됨 * 상세조회 -> lastviewdAt 업데이트 -> 최근 본 인사이트 카드 데이터로 추가됨
- Google 회원가입 시 비밀번호 입력 로직 제거 및 관련 필드 처리

## 🤔 궁금한점

## 📸 ScreenShot
