### PR TITLE
마이페이지 전체 조회 및 커뮤니티 제재 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ out/
 /src/main/resources/application-local.yml
 /src/main/resources/application-dev.yml
 /src/main/resources/application-prod.yml
+/src/main/resources/application-test.yml
+
 
 # macOS
 .DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	annotationProcessor 'org.projectlombok:lombok'
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+	//test lombok
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/welkit_server/domain/admin/controller/AdminController.java
+++ b/src/main/java/welkit_server/domain/admin/controller/AdminController.java
@@ -8,8 +8,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import welkit_server.domain.admin.dto.request.NoticeAdminRequest;
+import welkit_server.domain.admin.dto.response.AdminMainPageResponse;
+import welkit_server.domain.admin.dto.response.CommunityManagementPostDetailResponse;
 import welkit_server.domain.admin.dto.response.NoticeAdminResponse;
-import welkit_server.domain.admin.service.NoticeAdminService;
+import welkit_server.domain.admin.service.AdminService;
+import welkit_server.domain.admin.service.CommunityManagementService;
+import welkit_server.domain.admin.service.NoticeService;
+import welkit_server.domain.community.entity.CommunityPosts;
 import welkit_server.global.dto.SuccessResponse;
 import welkit_server.global.exception.message.SuccessMessage;
 
@@ -18,12 +23,25 @@ import welkit_server.global.exception.message.SuccessMessage;
 @RequestMapping("/admin")
 public class AdminController {
 
-    private final NoticeAdminService noticeAdminService;
+    private final NoticeService noticeService;
+    private final AdminService adminService;
+    private final CommunityManagementService communityManagementService;
+
+    @Operation(summary = "어드민 페이지 전체 조회", description = "어드민 페이지에 있는 공지사항과 제재 글 리스트를 모두 조회합니다")
+    @GetMapping
+    public ResponseEntity<SuccessResponse<AdminMainPageResponse>> getAdminMainPage(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Authentication authentication
+    ) {
+        AdminMainPageResponse adminMainPageResponse = adminService.getAdminMainPage(page, size, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, adminMainPageResponse));
+    }
 
     @Operation(summary = "공지사항 상세 조회", description = "등록되어 있는 공지사항을 상세 조회합니다")
     @GetMapping("/notices/{id}")
-    public ResponseEntity<SuccessResponse<NoticeAdminResponse>> getNotice(@PathVariable Long noticeId) {
-        NoticeAdminResponse notice= noticeAdminService.getNotice(noticeId);
+    public ResponseEntity<SuccessResponse<NoticeAdminResponse>> getNotice(@PathVariable("id") Long noticeId, Authentication authentication) {
+        NoticeAdminResponse notice= noticeService.getNotice(noticeId,authentication);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS,notice));
     }
 
@@ -33,7 +51,7 @@ public class AdminController {
             @Valid @RequestBody NoticeAdminRequest createNoticeRequest,
             Authentication authentication
     ) {
-        NoticeAdminResponse createNoticeResponse = noticeAdminService.createNotice(createNoticeRequest, authentication);
+        NoticeAdminResponse createNoticeResponse = noticeService.createNotice(createNoticeRequest, authentication);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessResponse.of(SuccessMessage.CREATED_SUCCESS, createNoticeResponse));
     }
@@ -45,7 +63,7 @@ public class AdminController {
             @PathVariable("id") Long noticeId,
             Authentication authentication
     ){
-        NoticeAdminResponse editNoticeResponse = noticeAdminService.updateNotice(noticeId, editNoticeRequest, authentication);
+        NoticeAdminResponse editNoticeResponse = noticeService.updateNotice(noticeId, editNoticeRequest, authentication);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponse.of(SuccessMessage.UPDATED_SUCCESS, editNoticeResponse));
     }
@@ -53,7 +71,21 @@ public class AdminController {
     @Operation(summary = "공지사항 삭제", description = "등록되어 있는 공지사항을 삭제합니다")
     @DeleteMapping("/notices/{id}")
     public ResponseEntity<SuccessResponse> deleteNotice(@PathVariable("id") Long noticeId, Authentication authentication) {
-        noticeAdminService.deleteNotice(noticeId, authentication);
+        noticeService.deleteNotice(noticeId, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.DELETED_SUCCESS));
+    }
+
+    @Operation(summary = "제재 커뮤니티 글 상세 조회", description = "제재할 커뮤니티 글을 상세 조회합니다")
+    @GetMapping("/sanction-posts/{id}")
+    public ResponseEntity<SuccessResponse<CommunityManagementPostDetailResponse>> getSectionPostById(@PathVariable("id") Long postId, Authentication authentication) {
+        CommunityManagementPostDetailResponse communityPosts = communityManagementService.getSanctionPostById(postId, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS,communityPosts));
+    }
+
+    @Operation(summary = "제재 커뮤니티 글 삭제",description = "제재할 커뮤니티 글을 삭제합니다")
+    @DeleteMapping("/sanction-posts/{id}")
+    public ResponseEntity<SuccessResponse> deleteSectionPostById(@PathVariable("id") Long postId,Authentication authentication) {
+        communityManagementService.deleteSanctionPostById(postId,authentication);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.DELETED_SUCCESS));
     }
 

--- a/src/main/java/welkit_server/domain/admin/controller/AdminController.java
+++ b/src/main/java/welkit_server/domain/admin/controller/AdminController.java
@@ -14,7 +14,6 @@ import welkit_server.domain.admin.dto.response.NoticeAdminResponse;
 import welkit_server.domain.admin.service.AdminService;
 import welkit_server.domain.admin.service.CommunityManagementService;
 import welkit_server.domain.admin.service.NoticeService;
-import welkit_server.domain.community.entity.CommunityPosts;
 import welkit_server.global.dto.SuccessResponse;
 import welkit_server.global.exception.message.SuccessMessage;
 

--- a/src/main/java/welkit_server/domain/admin/dto/response/AdminMainPageResponse.java
+++ b/src/main/java/welkit_server/domain/admin/dto/response/AdminMainPageResponse.java
@@ -1,7 +1,6 @@
 package welkit_server.domain.admin.dto.response;
 
 import lombok.*;
-
 import java.util.List;
 
 @Getter

--- a/src/main/java/welkit_server/domain/admin/dto/response/AdminMainPageResponse.java
+++ b/src/main/java/welkit_server/domain/admin/dto/response/AdminMainPageResponse.java
@@ -1,0 +1,16 @@
+package welkit_server.domain.admin.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class AdminMainPageResponse {
+
+    private List<GetAllNoticeResponse> noticeList;
+    private List<CommunityManagementPostResponse> communityManagementPosts;
+
+}

--- a/src/main/java/welkit_server/domain/admin/dto/response/CommunityManagementPostDetailResponse.java
+++ b/src/main/java/welkit_server/domain/admin/dto/response/CommunityManagementPostDetailResponse.java
@@ -9,11 +9,13 @@ import welkit_server.domain.community.entity.CommunityPosts;
 @Builder
 public class CommunityManagementPostDetailResponse {
 
+    private Long id;
     private String title;
     private String content;
 
     public static CommunityManagementPostDetailResponse fromEntity(CommunityPosts post) {
         return CommunityManagementPostDetailResponse.builder()
+                .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .build();

--- a/src/main/java/welkit_server/domain/admin/dto/response/CommunityManagementPostDetailResponse.java
+++ b/src/main/java/welkit_server/domain/admin/dto/response/CommunityManagementPostDetailResponse.java
@@ -1,0 +1,22 @@
+package welkit_server.domain.admin.dto.response;
+
+import lombok.*;
+import welkit_server.domain.community.entity.CommunityPosts;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CommunityManagementPostDetailResponse {
+
+    private String title;
+    private String content;
+
+    public static CommunityManagementPostDetailResponse fromEntity(CommunityPosts post) {
+        return CommunityManagementPostDetailResponse.builder()
+                .title(post.getTitle())
+                .content(post.getContent())
+                .build();
+    }
+}
+

--- a/src/main/java/welkit_server/domain/admin/dto/response/CommunityManagementPostResponse.java
+++ b/src/main/java/welkit_server/domain/admin/dto/response/CommunityManagementPostResponse.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 @Builder
 public class CommunityManagementPostResponse {
 
+    private Long id;
     private String title;
     private int notHelpfulCount;
     private LocalDateTime createdAt;
@@ -22,6 +23,7 @@ public class CommunityManagementPostResponse {
                 .count();
 
         return CommunityManagementPostResponse.builder()
+                .id(post.getId())
                 .title(post.getTitle())
                 .notHelpfulCount(notHelpfulCount)
                 .createdAt(post.getCreatedDate())

--- a/src/main/java/welkit_server/domain/admin/dto/response/CommunityManagementPostResponse.java
+++ b/src/main/java/welkit_server/domain/admin/dto/response/CommunityManagementPostResponse.java
@@ -1,0 +1,31 @@
+package welkit_server.domain.admin.dto.response;
+
+import lombok.*;
+import welkit_server.domain.community.entity.CommunityPosts;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CommunityManagementPostResponse {
+
+    private String title;
+    private int notHelpfulCount;
+    private LocalDateTime createdAt;
+
+    public static CommunityManagementPostResponse fromEntity(CommunityPosts post){
+
+        int notHelpfulCount = (int) post.getFeedbacks().stream()
+                .filter(f -> Boolean.FALSE.equals(f.getIsHelpful()))
+                .count();
+
+        return CommunityManagementPostResponse.builder()
+                .title(post.getTitle())
+                .notHelpfulCount(notHelpfulCount)
+                .createdAt(post.getCreatedDate())
+                .build();
+    }
+
+}

--- a/src/main/java/welkit_server/domain/admin/dto/response/GetAllNoticeResponse.java
+++ b/src/main/java/welkit_server/domain/admin/dto/response/GetAllNoticeResponse.java
@@ -1,9 +1,11 @@
 package welkit_server.domain.admin.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import welkit_server.domain.admin.entity.Notice;
 import welkit_server.domain.admin.model.NoticePriority;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Getter
@@ -16,7 +18,8 @@ public class GetAllNoticeResponse {
     private String title;
     private String content;
     private NoticePriority priority;
-    private String lastModified;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDateTime lastModified;
 
     public static GetAllNoticeResponse fromEntity(Notice notice) {
         return GetAllNoticeResponse.builder()
@@ -24,9 +27,9 @@ public class GetAllNoticeResponse {
                 .title(notice.getTitle())
                 .content(notice.getContent())
                 .priority(notice.getPriority())
-                .lastModified(notice.getLastModifiedDate()
-                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .lastModified(notice.getLastModifiedDate())
                 .build();
+
     }
 
 }

--- a/src/main/java/welkit_server/domain/admin/dto/response/GetAllNoticeResponse.java
+++ b/src/main/java/welkit_server/domain/admin/dto/response/GetAllNoticeResponse.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import welkit_server.domain.admin.entity.Notice;
 import welkit_server.domain.admin.model.NoticePriority;
-
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/welkit_server/domain/admin/service/AdminService.java
+++ b/src/main/java/welkit_server/domain/admin/service/AdminService.java
@@ -1,0 +1,49 @@
+package welkit_server.domain.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import welkit_server.domain.admin.dto.response.AdminMainPageResponse;
+import welkit_server.domain.admin.dto.response.CommunityManagementPostResponse;
+import welkit_server.domain.admin.dto.response.GetAllNoticeResponse;
+import welkit_server.domain.user.entity.User;
+import welkit_server.domain.user.repository.UserRepository;
+import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.UnauthorizedException;
+import welkit_server.global.security.dto.CustomUserDetails;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminService {
+
+    private final NoticeService noticeService;
+    private final CommunityManagementService communityManagementService;
+    private final UserRepository userRepository;
+
+    public AdminMainPageResponse getAdminMainPage(int page, int size, Authentication authentication) {
+        getAuthenticatedUser(authentication);
+
+        List<GetAllNoticeResponse> notices = noticeService.getAllNotices(authentication);
+        List<CommunityManagementPostResponse> sanctionPosts = communityManagementService.getAllSanctionPosts(page, size,authentication);
+
+        return AdminMainPageResponse.builder()
+                .noticeList(notices)
+                .communityManagementPosts(sanctionPosts)
+                .build();
+
+    }
+
+    public Long getAuthenticatedUserId(Authentication authentication) {
+        return ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+    }
+
+    public User getAuthenticatedUser(Authentication authentication) {
+        return userRepository.findById(getAuthenticatedUserId(authentication))
+                .orElseThrow(() -> new UnauthorizedException(ErrorMessage.SESSION_EXPIRED));
+    }
+
+}

--- a/src/main/java/welkit_server/domain/admin/service/AdminService.java
+++ b/src/main/java/welkit_server/domain/admin/service/AdminService.java
@@ -12,7 +12,6 @@ import welkit_server.domain.user.repository.UserRepository;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.UnauthorizedException;
 import welkit_server.global.security.dto.CustomUserDetails;
-
 import java.util.List;
 
 @Service

--- a/src/main/java/welkit_server/domain/admin/service/CommunityManagementService.java
+++ b/src/main/java/welkit_server/domain/admin/service/CommunityManagementService.java
@@ -42,4 +42,10 @@ public class CommunityManagementService {
         return CommunityManagementPostDetailResponse.fromEntity(getSectionPost);
     }
 
+    public void deleteSanctionPostById(Long postId) {
+        CommunityPosts getSectionPost = communityPostRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMUNITY_POST_NOT_FOUND));
+        communityPostRepository.delete(getSectionPost);
+    }
+
 }

--- a/src/main/java/welkit_server/domain/admin/service/CommunityManagementService.java
+++ b/src/main/java/welkit_server/domain/admin/service/CommunityManagementService.java
@@ -48,7 +48,8 @@ public class CommunityManagementService {
         return CommunityManagementPostDetailResponse.fromEntity(getSectionPost);
     }
 
-    public void deleteSanctionPostById(Long postId,Authentication authentication) {
+    @Transactional
+    public void deleteSanctionPostById(Long postId, Authentication authentication) {
         getAuthenticatedUser(authentication);
 
         CommunityPosts getSectionPost = communityPostRepository.findById(postId)

--- a/src/main/java/welkit_server/domain/admin/service/CommunityManagementService.java
+++ b/src/main/java/welkit_server/domain/admin/service/CommunityManagementService.java
@@ -1,6 +1,5 @@
 package welkit_server.domain.admin.service;
 
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;

--- a/src/main/java/welkit_server/domain/admin/service/CommunityManagementService.java
+++ b/src/main/java/welkit_server/domain/admin/service/CommunityManagementService.java
@@ -2,17 +2,22 @@ package welkit_server.domain.admin.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.admin.dto.response.CommunityManagementPostDetailResponse;
 import welkit_server.domain.admin.dto.response.CommunityManagementPostResponse;
 import welkit_server.domain.community.entity.CommunityPosts;
 import welkit_server.domain.community.repository.CommunityPostRepository;
+import welkit_server.domain.user.entity.User;
+import welkit_server.domain.user.repository.UserRepository;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.NotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
+import welkit_server.global.exception.model.UnauthorizedException;
+import welkit_server.global.security.dto.CustomUserDetails;
 import java.util.List;
 
 @Service
@@ -21,11 +26,12 @@ import java.util.List;
 public class CommunityManagementService {
 
     private final CommunityPostRepository communityPostRepository;
+    private final UserRepository userRepository;
 
+    public List<CommunityManagementPostResponse> getAllSanctionPosts(int page, int size, Authentication authentication) {
+        getAuthenticatedUser(authentication);
 
-    public List<CommunityManagementPostResponse> getAllSanctionPosts(int page, int size) {
-
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page,size);
 
         Page<CommunityPosts> communityPosts = communityPostRepository.findSanctionPosts(pageable);
 
@@ -34,7 +40,8 @@ public class CommunityManagementService {
                 .toList();
     }
 
-    public CommunityManagementPostDetailResponse getSanctionPostById(Long postId) {
+    public CommunityManagementPostDetailResponse getSanctionPostById(Long postId,Authentication authentication) {
+        getAuthenticatedUser(authentication);
 
         CommunityPosts getSectionPost = communityPostRepository.findSanctionPostById(postId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMUNITY_POST_NOT_FOUND));
@@ -42,10 +49,21 @@ public class CommunityManagementService {
         return CommunityManagementPostDetailResponse.fromEntity(getSectionPost);
     }
 
-    public void deleteSanctionPostById(Long postId) {
+    public void deleteSanctionPostById(Long postId,Authentication authentication) {
+        getAuthenticatedUser(authentication);
+
         CommunityPosts getSectionPost = communityPostRepository.findById(postId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMUNITY_POST_NOT_FOUND));
         communityPostRepository.delete(getSectionPost);
+    }
+
+    public Long getAuthenticatedUserId(Authentication authentication) {
+        return ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+    }
+
+    public User getAuthenticatedUser(Authentication authentication) {
+        return userRepository.findById(getAuthenticatedUserId(authentication))
+                .orElseThrow(() -> new UnauthorizedException(ErrorMessage.SESSION_EXPIRED));
     }
 
 }

--- a/src/main/java/welkit_server/domain/admin/service/CommunityManagementService.java
+++ b/src/main/java/welkit_server/domain/admin/service/CommunityManagementService.java
@@ -1,0 +1,45 @@
+package welkit_server.domain.admin.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import welkit_server.domain.admin.dto.response.CommunityManagementPostDetailResponse;
+import welkit_server.domain.admin.dto.response.CommunityManagementPostResponse;
+import welkit_server.domain.community.entity.CommunityPosts;
+import welkit_server.domain.community.repository.CommunityPostRepository;
+import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.NotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommunityManagementService {
+
+    private final CommunityPostRepository communityPostRepository;
+
+
+    public List<CommunityManagementPostResponse> getAllSanctionPosts(int page, int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<CommunityPosts> communityPosts = communityPostRepository.findSanctionPosts(pageable);
+
+        return communityPosts.getContent().stream()
+                .map(CommunityManagementPostResponse::fromEntity)
+                .toList();
+    }
+
+    public CommunityManagementPostDetailResponse getSanctionPostById(Long postId) {
+
+        CommunityPosts getSectionPost = communityPostRepository.findSanctionPostById(postId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMUNITY_POST_NOT_FOUND));
+
+        return CommunityManagementPostDetailResponse.fromEntity(getSectionPost);
+    }
+
+}

--- a/src/main/java/welkit_server/domain/admin/service/NoticeService.java
+++ b/src/main/java/welkit_server/domain/admin/service/NoticeService.java
@@ -20,42 +20,52 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class NoticeAdminService {
+public class NoticeService {
 
     private final NoticeRepository noticeRepository;
     private final UserRepository userRepository;
 
-    public List<GetAllNoticeResponse> getAllNotices() {
+    public List<GetAllNoticeResponse> getAllNotices(Authentication authentication) {
+        getAuthenticatedUser(authentication);
+
         return noticeRepository.findAllByOrderByLastModifiedDateDesc()
                 .stream()
                 .map(notice -> GetAllNoticeResponse.fromEntity(notice))
                 .toList();
     }
 
-    public NoticeAdminResponse getNotice(Long noticeId) {
+    public NoticeAdminResponse getNotice(Long noticeId, Authentication authentication) {
+        getAuthenticatedUser(authentication);
+
         Notice notice = findNoticeById(noticeId);
+
         return NoticeAdminResponse.fromEntity(notice);
     }
 
     @Transactional
     public NoticeAdminResponse createNotice(NoticeAdminRequest createNoticeRequest, Authentication authentication) {
         getAuthenticatedUser(authentication);
+
         Notice notice = createNoticeRequest.toEntity();
         noticeRepository.save(notice);
+
         return NoticeAdminResponse.fromEntity(notice);
     }
 
     @Transactional
     public NoticeAdminResponse updateNotice(Long noticeId, NoticeAdminRequest updateNoticeRequest, Authentication authentication) {
         getAuthenticatedUser(authentication);
+
         Notice notice = findNoticeById(noticeId);
         notice.editNotice(updateNoticeRequest);
+
         return NoticeAdminResponse.fromEntity(notice);
     }
 
     @Transactional
     public void deleteNotice(Long noticeId, Authentication authentication) {
         getAuthenticatedUser(authentication);
+
         Notice notice = findNoticeById(noticeId);
         noticeRepository.delete(notice);
     }

--- a/src/main/java/welkit_server/domain/community/entity/CommunityPosts.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityPosts.java
@@ -44,7 +44,7 @@ public class CommunityPosts extends BaseEntity {
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CommunityComments> comments = new ArrayList<>();
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @Where(clause = "target_type = 'POSTS'")
     @JoinColumn(name = "target_id", insertable = false, updatable = false)
     private List<CommunityFeedBack> feedbacks = new ArrayList<>();

--- a/src/main/java/welkit_server/domain/community/repository/CommunityPostRepository.java
+++ b/src/main/java/welkit_server/domain/community/repository/CommunityPostRepository.java
@@ -10,6 +10,7 @@ import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.model.JobRole;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CommunityPostRepository extends JpaRepository<CommunityPosts, Long> {
     Page<CommunityPosts> findAllByJobRole(JobRole jobRole, Pageable pageable);
@@ -43,4 +44,27 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPosts, L
        OR LOWER(p.content) LIKE LOWER(CONCAT('%', COALESCE(:keyword, ''), '%')))
     """)
     Page<CommunityPosts> searchPostsOptionalKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("""
+    SELECT p
+    FROM CommunityPosts p
+    JOIN p.feedbacks f
+    WHERE f.isHelpful = false
+    GROUP BY p
+    HAVING COUNT(f) >= 10
+    ORDER BY p.createdDate DESC
+""")
+    Page<CommunityPosts> findSanctionPosts(Pageable pageable);
+
+    @Query("""
+    SELECT p
+    FROM CommunityPosts p
+    JOIN p.feedbacks f
+    WHERE f.isHelpful = false
+    AND p.id = :postId
+    GROUP BY p
+    HAVING COUNT(f) >= 10
+""")
+    Optional<CommunityPosts> findSanctionPostById(@Param("postId") Long postId);
+
 }

--- a/src/main/java/welkit_server/domain/community/repository/CommunityPostRepository.java
+++ b/src/main/java/welkit_server/domain/community/repository/CommunityPostRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.repository.query.Param;
 import welkit_server.domain.community.entity.CommunityPosts;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.model.JobRole;
-
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/welkit_server/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/welkit_server/domain/mypage/controller/MyPageController.java
@@ -14,6 +14,7 @@ import welkit_server.domain.mypage.dto.request.FeatureLockSettingRequest;
 import welkit_server.domain.mypage.dto.request.LockSettingRequest;
 import welkit_server.domain.mypage.dto.request.SolveLockRequest;
 import welkit_server.domain.mypage.dto.response.FeatureLockSettingResponse;
+import welkit_server.domain.mypage.dto.response.MyPageResponse;
 import welkit_server.domain.mypage.service.MyPageService;
 import welkit_server.global.dto.SuccessResponse;
 import welkit_server.global.exception.message.SuccessMessage;
@@ -24,6 +25,13 @@ import welkit_server.global.exception.message.SuccessMessage;
 public class MyPageController {
 
     private final MyPageService mypageService;
+
+    @Operation(summary = "전체 마이페이지 조회", description = "사용자의 정보, 공지사항, 기능별 암호 설정 상태를 포함한 마이페이지 전체 데이터를 조회합니다 ")
+    @GetMapping
+    public ResponseEntity<SuccessResponse<MyPageResponse>> getAllMyPages(Authentication authentication) {
+        MyPageResponse mypage = mypageService.getMyPage(authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS,mypage));
+    }
 
     @Operation(summary = "암호 생성", description = "기능별 암호 설정을 위한 암호를 생성합니다")
     @PutMapping("/lock/pin")

--- a/src/main/java/welkit_server/domain/mypage/dto/response/MyPageResponse.java
+++ b/src/main/java/welkit_server/domain/mypage/dto/response/MyPageResponse.java
@@ -1,0 +1,17 @@
+package welkit_server.domain.mypage.dto.response;
+
+import lombok.*;
+import welkit_server.domain.admin.dto.response.GetAllNoticeResponse;
+import welkit_server.domain.user.dto.UserInfoResponse;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class MyPageResponse {
+    private UserInfoResponse user;
+    private List<GetAllNoticeResponse> noticeList;
+    private List<FeatureLockSettingResponse> lockSettings;
+}

--- a/src/main/java/welkit_server/domain/mypage/repository/LockSettingRepository.java
+++ b/src/main/java/welkit_server/domain/mypage/repository/LockSettingRepository.java
@@ -7,9 +7,14 @@ import org.springframework.stereotype.Repository;
 import welkit_server.domain.mypage.entity.LockSetting;
 import welkit_server.domain.mypage.model.FeatureName;
 
+import java.util.List;
+
 @Repository
 public interface LockSettingRepository extends JpaRepository<LockSetting, Long> {
 
     LockSetting findByUserIdAndFeatureName(Long userId, FeatureName featureName);
+
+    @Query("SELECT l FROM LockSetting l WHERE l.user.id = :userId")
+    List<LockSetting> findByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
+++ b/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
@@ -7,7 +7,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.admin.dto.response.GetAllNoticeResponse;
-import welkit_server.domain.admin.service.NoticeAdminService;
+import welkit_server.domain.admin.service.NoticeService;
 import welkit_server.domain.mail.dto.request.EmailPostRequest;
 import welkit_server.domain.mail.dto.request.EmailVerifyRequest;
 import welkit_server.domain.mail.dto.response.EmailResponse;
@@ -40,7 +40,7 @@ public class MyPageService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder encoder;
-    private final NoticeAdminService noticeAdminService;
+    private final NoticeService noticeService;
     private final LockSettingRepository lockSettingRepository;
     private final RedisTemplate<String, String> redisTemplate;
     private final RedisUtil redisUtil;
@@ -50,7 +50,7 @@ public class MyPageService {
     public MyPageResponse getMyPage(Authentication authentication) {
 
         UserInfoResponse user = getUserInfo(authentication);
-        List<GetAllNoticeResponse> notices = noticeAdminService.getAllNotices();
+        List<GetAllNoticeResponse> notices = noticeService.getAllNotices(authentication);
         List<FeatureLockSettingResponse> lockSettings =
                 lockSettingRepository.findByUserId(user.getId()).stream()
                         .map(FeatureLockSettingResponse::fromEntity)

--- a/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
+++ b/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
@@ -6,6 +6,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import welkit_server.domain.admin.dto.response.GetAllNoticeResponse;
+import welkit_server.domain.admin.service.NoticeAdminService;
 import welkit_server.domain.mail.dto.request.EmailPostRequest;
 import welkit_server.domain.mail.dto.request.EmailVerifyRequest;
 import welkit_server.domain.mail.dto.response.EmailResponse;
@@ -14,9 +16,11 @@ import welkit_server.domain.mypage.dto.request.FeatureLockSettingRequest;
 import welkit_server.domain.mypage.dto.request.LockSettingRequest;
 import welkit_server.domain.mypage.dto.request.SolveLockRequest;
 import welkit_server.domain.mypage.dto.response.FeatureLockSettingResponse;
+import welkit_server.domain.mypage.dto.response.MyPageResponse;
 import welkit_server.domain.mypage.entity.LockSetting;
 import welkit_server.domain.mypage.model.FeatureName;
 import welkit_server.domain.mypage.repository.LockSettingRepository;
+import welkit_server.domain.user.dto.UserInfoResponse;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.model.EmailType;
 import welkit_server.domain.user.repository.UserRepository;
@@ -36,12 +40,33 @@ public class MyPageService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder encoder;
+    private final NoticeAdminService noticeAdminService;
     private final LockSettingRepository lockSettingRepository;
     private final RedisTemplate<String, String> redisTemplate;
     private final RedisUtil redisUtil;
     private final EmailService emailService;
     private final BlockedDomainsConfig blockedDomainsConfig;
 
+    public MyPageResponse getMyPage(Authentication authentication) {
+
+        UserInfoResponse user = getUserInfo(authentication);
+        List<GetAllNoticeResponse> notices = noticeAdminService.getAllNotices();
+        List<FeatureLockSettingResponse> lockSettings =
+                lockSettingRepository.findByUserId(user.getId()).stream()
+                        .map(FeatureLockSettingResponse::fromEntity)
+                        .toList();
+
+        return MyPageResponse.builder()
+                .user(user)
+                .noticeList(notices)
+                .lockSettings(lockSettings)
+                .build();
+    }
+
+    public UserInfoResponse getUserInfo(Authentication authentication) {
+        User user = getAuthenticatedUser(authentication);
+        return UserInfoResponse.fromEntity(user);
+    }
 
     @Transactional
     public void setLock(LockSettingRequest lockSettingRequest, Authentication authentication) {

--- a/src/main/java/welkit_server/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/welkit_server/domain/user/dto/UserInfoResponse.java
@@ -1,0 +1,28 @@
+package welkit_server.domain.user.dto;
+
+import lombok.*;
+import welkit_server.domain.user.entity.User;
+import welkit_server.domain.user.model.EmailType;
+import welkit_server.domain.user.model.UserType;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class UserInfoResponse {
+    private Long id;
+    private String email;
+    private EmailType emailType;
+    private boolean isCompanyVerified;
+    private UserType userType;
+
+    public static UserInfoResponse fromEntity(User user) {
+        return UserInfoResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail() != null ? user.getEmail() : user.getGoogleEmail())
+                .emailType(user.getEmailType())
+                .isCompanyVerified(user.isCompanyVerified())
+                .userType(user.getUserType())
+                .build();
+    }
+}

--- a/src/test/java/welkit_server/config/TestConfig.java
+++ b/src/test/java/welkit_server/config/TestConfig.java
@@ -1,0 +1,26 @@
+package welkit_server.config;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@AutoConfigureMockMvc
+@Import({TestConfig.Sample.class})
+
+public @interface TestConfig {
+    class Sample {
+        @Bean
+        MockMvcBuilderCustomizer utf8Config() {
+            return builder ->
+                    builder.addFilters(new CharacterEncodingFilter("UTF-8", true));
+        }
+    }
+}

--- a/src/test/java/welkit_server/user/controller/UserControllerTest.java
+++ b/src/test/java/welkit_server/user/controller/UserControllerTest.java
@@ -1,0 +1,45 @@
+package welkit_server.user.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import welkit_server.config.TestConfig;
+import welkit_server.domain.user.model.JobRole;
+import welkit_server.user.service.UserServiceTest;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@TestConfig
+@Transactional
+public class UserControllerTest {
+
+    @Autowired
+    private UserServiceTest userServiceTest;
+
+    @Test
+    @DisplayName("테스트용 10명 회원 생성")
+    @Rollback(false)
+    void createTenUsersBDD() {
+        // given
+        int numberOfUsers = 10;
+        // when
+        for (int i = 1; i <= numberOfUsers; i++) {
+            userServiceTest.signupDirectly(
+                    "test" + i + "@gmail.com",
+                    "12345678!",
+                    JobRole.AI_DEVELOP_DATA
+            );
+        }
+        // then
+        long count = userServiceTest.getUserRepository().count();
+        assertThat(count).isGreaterThanOrEqualTo(numberOfUsers);
+    }
+
+}

--- a/src/test/java/welkit_server/user/service/UserServiceTest.java
+++ b/src/test/java/welkit_server/user/service/UserServiceTest.java
@@ -1,0 +1,48 @@
+package welkit_server.user.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import welkit_server.domain.mypage.entity.LockSetting;
+import welkit_server.domain.mypage.model.FeatureName;
+import welkit_server.domain.mypage.repository.LockSettingRepository;
+import welkit_server.domain.user.entity.User;
+import welkit_server.domain.user.model.EmailType;
+import welkit_server.domain.user.model.JobRole;
+import welkit_server.domain.user.repository.UserRepository;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@Profile("test")
+@RequiredArgsConstructor
+@Getter
+public class UserServiceTest {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final LockSettingRepository lockSettingRepository;
+
+    public void signupDirectly(String email, String password, JobRole jobRole) {
+        User user = userRepository.save(User.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .jobRole(jobRole)
+                .isCompanyVerified(false) // 테스트에서 바로 인증 완료
+                .emailType(EmailType.PERSONAL_EMAIL)
+                .build());
+
+        List<LockSetting> lockSettings = Arrays.stream(FeatureName.values())
+                .map(feature -> LockSetting.builder()
+                        .user(user)
+                        .featureName(feature)
+                        .isLocked(false)
+                        .build())
+                .toList();
+
+        lockSettingRepository.saveAll(lockSettings);
+    }
+
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #30
## ✅ 작업 리스트
- [x] 마이페이지 전체 조회
- [x] 커뮤니티 제재 기능 구현
- [x] 어드민 전체 조회

## 🔧 작업 내용
- 테스트 코드 작성하여, User 10명 테스트 데이터 생성
- 마이페이지 전체 조회시, 공지사항 / 사용자 이메일 인증 여부 / 잠금 설정 조회 가능  (공지사항 상세 조회 가능)
- 커뮤니티 제재는 `notHelpfulCount ` 가 10개 이상인 게시글만 해당이 됨
- 어드민 페이지 전체 조회시, 공지사항 / 커뮤니티 제재 재상 게시글 조회 가능 (공지사항 상세조회 가능)
- 어드민 페이지에서 커뮤니티 제재 게시글 상세 조회가능 (제목 / notHelpfulCount 개수 / 내용 / 생성일 )
- 어드민 페이지에서 커뮤니티 제재 게시글 삭제시, 삭제 게시글의 FeedBacks 도 자동 삭제 *(cascade = CascadeType.REMOVE)
- 어드민 페이지 커뮤니티 제재 게시글을 한 페이지당 10개씩 조회가 가능 * 공지사항은 따로 페이징 적용 안함

## 🤔 궁금한점

## 📸 ScreenShot
