### PR TITLE
마이페이지 내 직무 변경 기능 추가

### DIFF
--- a/src/main/java/welkit_server/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/welkit_server/domain/mypage/controller/MyPageController.java
@@ -13,8 +13,10 @@ import welkit_server.domain.mail.dto.response.EmailResponse;
 import welkit_server.domain.mypage.dto.request.FeatureLockSettingRequest;
 import welkit_server.domain.mypage.dto.request.LockSettingRequest;
 import welkit_server.domain.mypage.dto.request.SolveLockRequest;
+import welkit_server.domain.mypage.dto.request.UpdateJobRoleRequest;
 import welkit_server.domain.mypage.dto.response.FeatureLockSettingResponse;
 import welkit_server.domain.mypage.dto.response.MyPageResponse;
+import welkit_server.domain.mypage.dto.response.UpdateJobRoleResponse;
 import welkit_server.domain.mypage.service.MyPageService;
 import welkit_server.global.dto.SuccessResponse;
 import welkit_server.global.exception.message.SuccessMessage;
@@ -93,6 +95,18 @@ public class MyPageController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of(SuccessMessage.COMPANY_EMAIL_VERIFICATION_SUCCESS, null));
+    }
+
+    @Operation(summary = "사용자 직무 변경", description = "사용자가 마이페이지에서 자신의 직무(Job Role)를 변경합니다")
+    @PatchMapping("/job")
+    public ResponseEntity<SuccessResponse<UpdateJobRoleResponse>> updateJobRole(
+            @Valid @RequestBody UpdateJobRoleRequest updateJobRoleRequest,
+            Authentication authentication
+    ) {
+        UpdateJobRoleResponse response = mypageService.updateJobRole(updateJobRoleRequest, authentication);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessMessage.UPDATED_SUCCESS, response));
     }
 
 }

--- a/src/main/java/welkit_server/domain/mypage/dto/request/UpdateJobRoleRequest.java
+++ b/src/main/java/welkit_server/domain/mypage/dto/request/UpdateJobRoleRequest.java
@@ -1,0 +1,14 @@
+package welkit_server.domain.mypage.dto.request;
+
+import lombok.*;
+import welkit_server.domain.user.model.JobRole;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class UpdateJobRoleRequest {
+
+    private JobRole jobRole;
+
+}

--- a/src/main/java/welkit_server/domain/mypage/dto/response/UpdateJobRoleResponse.java
+++ b/src/main/java/welkit_server/domain/mypage/dto/response/UpdateJobRoleResponse.java
@@ -1,0 +1,14 @@
+package welkit_server.domain.mypage.dto.response;
+
+import lombok.*;
+import welkit_server.domain.user.model.JobRole;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class UpdateJobRoleResponse {
+
+    private JobRole jobRole;
+
+}

--- a/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
+++ b/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
@@ -15,14 +15,17 @@ import welkit_server.domain.mail.service.EmailService;
 import welkit_server.domain.mypage.dto.request.FeatureLockSettingRequest;
 import welkit_server.domain.mypage.dto.request.LockSettingRequest;
 import welkit_server.domain.mypage.dto.request.SolveLockRequest;
+import welkit_server.domain.mypage.dto.request.UpdateJobRoleRequest;
 import welkit_server.domain.mypage.dto.response.FeatureLockSettingResponse;
 import welkit_server.domain.mypage.dto.response.MyPageResponse;
+import welkit_server.domain.mypage.dto.response.UpdateJobRoleResponse;
 import welkit_server.domain.mypage.entity.LockSetting;
 import welkit_server.domain.mypage.model.FeatureName;
 import welkit_server.domain.mypage.repository.LockSettingRepository;
 import welkit_server.domain.user.dto.UserInfoResponse;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.model.EmailType;
+import welkit_server.domain.user.model.JobRole;
 import welkit_server.domain.user.repository.UserRepository;
 import welkit_server.global.config.BlockedDomainsConfig;
 import welkit_server.global.exception.message.ErrorMessage;
@@ -152,6 +155,17 @@ public class MyPageService {
             throw new BadRequestException(ErrorMessage.USR_EMAIL_COMPANY_DOMAIN_INVALID);
         }
         user.setEmailType(EmailType.COMPANY_EMAIL);
+    }
+
+    @Transactional
+    public UpdateJobRoleResponse updateJobRole(UpdateJobRoleRequest updateJobRoleRequest, Authentication authentication) {
+        User user = getAuthenticatedUser(authentication);
+        JobRole jobRole = updateJobRoleRequest.getJobRole();
+        user.updateJobRole(jobRole);
+
+        return UpdateJobRoleResponse.builder()
+                .jobRole(jobRole)
+                .build();
     }
 
     public Long getAuthenticatedUserId(Authentication authentication) {

--- a/src/main/java/welkit_server/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/welkit_server/domain/user/dto/UserInfoResponse.java
@@ -3,6 +3,7 @@ package welkit_server.domain.user.dto;
 import lombok.*;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.model.EmailType;
+import welkit_server.domain.user.model.JobRole;
 import welkit_server.domain.user.model.UserType;
 
 @Getter
@@ -14,6 +15,7 @@ public class UserInfoResponse {
     private String email;
     private EmailType emailType;
     private boolean isCompanyVerified;
+    private JobRole jobRole;
     private UserType userType;
 
     public static UserInfoResponse fromEntity(User user) {
@@ -22,6 +24,7 @@ public class UserInfoResponse {
                 .email(user.getEmail() != null ? user.getEmail() : user.getGoogleEmail())
                 .emailType(user.getEmailType())
                 .isCompanyVerified(user.isCompanyVerified())
+                .jobRole(user.getJobRole())
                 .userType(user.getUserType())
                 .build();
     }

--- a/src/main/java/welkit_server/domain/user/entity/User.java
+++ b/src/main/java/welkit_server/domain/user/entity/User.java
@@ -64,4 +64,8 @@ public class User extends BaseEntity {
         this.emailType = emailType;
     }
 
+    public void updateJobRole(JobRole newRole){
+        this.jobRole = newRole;
+    }
+
 }


### PR DESCRIPTION
## 🔥 Related Issues
- #34 

## ✅ 작업 리스트
- [x] 마이페이지 에서 자신의 직무 변경 로직 구현
- [x] 마이페이지 전체 조회시 User 의 직무 정보까지 반환

## 🔧 작업 내용
- 로그인 한 사용자가 자신의 직무를 변경할 수 있도록 마이페이지 직무 변경 API 구현
- 마이페이지 전체 조회 API 응답에 `jobRole` 필드 추가

## 🤔 궁금한점

## 📸 ScreenShot
