### PR TITLE
기능별 조회 기능 페이징 적용

### DIFF
--- a/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
+++ b/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import welkit_server.domain.insightcard.dto.request.InsightCardRequest;
 import welkit_server.domain.insightcard.dto.response.GetAllInsightCardResponse;
+import welkit_server.domain.insightcard.dto.response.GetInsightCardResponse;
 import welkit_server.domain.insightcard.dto.response.InsightCardResponse;
 import welkit_server.domain.insightcard.model.CardType;
 import welkit_server.domain.insightcard.service.InsightCardService;
@@ -25,8 +26,12 @@ public class InsightCardController {
 
     @Operation(summary = "인물 카드 전체 조회", description = "등록된 인물 카드를 전체 조회합니다")
     @GetMapping("/person")
-    public ResponseEntity<SuccessResponse<GetAllInsightCardResponse>> getAllInsightPersonCard(Authentication authentication) {
-        List<GetAllInsightCardResponse> insightPersonCards = insightCardService.getAllInsightPersonCards(authentication);
+    public ResponseEntity<SuccessResponse<GetInsightCardResponse>> getAllInsightPersonCard(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Authentication authentication
+    ) {
+        GetInsightCardResponse insightPersonCards = insightCardService.getAllInsightPersonCards(page, size, authentication);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, insightPersonCards));
     }
 
@@ -82,8 +87,12 @@ public class InsightCardController {
 
     @Operation(summary = "업무 카드 전체 조회", description = "등록된 업무 카드를 전체 조회합니다")
     @GetMapping("/work")
-    public ResponseEntity<SuccessResponse<GetAllInsightCardResponse>> getAllInsightWorkCard(Authentication authentication) {
-        List<GetAllInsightCardResponse> insightWorkCards = insightCardService.getAllInsightWorkCards(authentication);
+    public ResponseEntity<SuccessResponse<GetInsightCardResponse>> getAllInsightWorkCard(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Authentication authentication
+    ) {
+        GetInsightCardResponse insightWorkCards = insightCardService.getAllInsightWorkCards(page, size, authentication);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, insightWorkCards));
     }
 

--- a/src/main/java/welkit_server/domain/insightcard/dto/response/GetInsightCardResponse.java
+++ b/src/main/java/welkit_server/domain/insightcard/dto/response/GetInsightCardResponse.java
@@ -1,0 +1,13 @@
+package welkit_server.domain.insightcard.dto.response;
+
+import lombok.*;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class GetInsightCardResponse {
+    private Long totalAmount;
+    private List<GetAllInsightCardResponse> cards;
+}

--- a/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
+++ b/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
@@ -1,5 +1,7 @@
 package welkit_server.domain.insightcard.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,12 +17,15 @@ public interface InsightCardRepository extends JpaRepository<InsightCard, Long> 
     @Query("SELECT i FROM InsightCard i " +
             "WHERE i.user = :user AND i.type = 'PERSON' " +
             "ORDER BY i.updatedAt DESC")
-    List<InsightCard> findAllInsightPersonCards(@Param("user") User user);
+    Page<InsightCard> findAllInsightPersonCards(@Param("user") User user, Pageable pageable);
 
     @Query("SELECT i FROM InsightCard i " +
             "WHERE i.user = :user AND i.type = 'WORK' " +
             "ORDER BY i.updatedAt DESC")
-    List<InsightCard> findAllInsightWorkCards(@Param("user") User user);
+    Page<InsightCard> findAllInsightWorkCards(@Param("user") User user,Pageable pageable);
 
     List<InsightCard> findTop4ByUserIdAndTypeAndLastViewedAtIsNotNullOrderByLastViewedAtDesc(Long userId, CardType type);
+
+    long countByUserAndType(User user, CardType type);
+
 }

--- a/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
+++ b/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
@@ -22,7 +22,6 @@ import welkit_server.global.exception.model.NotFoundException;
 import welkit_server.global.exception.model.UnauthorizedException;
 import welkit_server.global.security.dto.CustomUserDetails;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -51,7 +50,7 @@ public class InsightCardService {
                         .lastViewedAt(insightCard.getLastViewedAt())
                         .updatedAt(insightCard.getLastModifiedDate())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
 
         return GetInsightCardResponse.builder()
                 .totalAmount(totalPersonCardAmount)
@@ -78,7 +77,7 @@ public class InsightCardService {
                         .lastViewedAt(insightCard.getLastViewedAt())
                         .updatedAt(insightCard.getLastModifiedDate())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
 
         return GetInsightCardResponse.builder()
                 .totalAmount(totalWorkCardAmount)

--- a/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
+++ b/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
@@ -1,11 +1,15 @@
 package welkit_server.domain.insightcard.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.insightcard.dto.request.InsightCardRequest;
 import welkit_server.domain.insightcard.dto.response.GetAllInsightCardResponse;
+import welkit_server.domain.insightcard.dto.response.GetInsightCardResponse;
 import welkit_server.domain.insightcard.dto.response.InsightCardResponse;
 import welkit_server.domain.insightcard.entity.InsightCard;
 import welkit_server.domain.insightcard.model.CardType;
@@ -18,6 +22,7 @@ import welkit_server.global.exception.model.NotFoundException;
 import welkit_server.global.exception.model.UnauthorizedException;
 import welkit_server.global.security.dto.CustomUserDetails;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,12 +32,15 @@ public class InsightCardService {
     private final InsightCardRepository insightCardRepository;
     private final UserRepository userRepository;
 
-    public List<GetAllInsightCardResponse> getAllInsightPersonCards(Authentication authentication) {
+    public GetInsightCardResponse getAllInsightPersonCards(int page, int size, Authentication authentication) {
         User currentUser = getAuthenticatedUser(authentication);
 
-        List<InsightCard> insightCards = insightCardRepository.findAllInsightPersonCards(currentUser);
+        Pageable pageable = PageRequest.of(page, size);
+        Page<InsightCard> insightCards = insightCardRepository.findAllInsightPersonCards(currentUser,pageable);
 
-        return insightCards.stream()
+        long totalPersonCardAmount = insightCardRepository.countByUserAndType(currentUser, CardType.PERSON);
+
+        List<GetAllInsightCardResponse> personWorkList = insightCards.stream()
                 .map(insightCard -> GetAllInsightCardResponse.builder()
                         .cardId(insightCard.getId())
                         .title(insightCard.getTitle())
@@ -43,15 +51,23 @@ public class InsightCardService {
                         .lastViewedAt(insightCard.getLastViewedAt())
                         .updatedAt(insightCard.getLastModifiedDate())
                         .build())
-                .toList();
+                .collect(Collectors.toList());
+
+        return GetInsightCardResponse.builder()
+                .totalAmount(totalPersonCardAmount)
+                .cards(personWorkList)
+                .build();
     }
 
-    public List<GetAllInsightCardResponse> getAllInsightWorkCards(Authentication authentication) {
+    public GetInsightCardResponse getAllInsightWorkCards(int page, int size, Authentication authentication) {
         User currentUser = getAuthenticatedUser(authentication);
 
-        List<InsightCard> insightCards = insightCardRepository.findAllInsightWorkCards(currentUser);
+        Pageable pageable = PageRequest.of(page, size);
+        Page<InsightCard> insightCards = insightCardRepository.findAllInsightWorkCards(currentUser, pageable);
 
-        return insightCards.stream()
+        long totalWorkCardAmount = insightCardRepository.countByUserAndType(currentUser, CardType.WORK);
+
+        List<GetAllInsightCardResponse> workCardList = insightCards.stream()
                 .map(insightCard -> GetAllInsightCardResponse.builder()
                         .cardId(insightCard.getId())
                         .title(insightCard.getTitle())
@@ -62,7 +78,12 @@ public class InsightCardService {
                         .lastViewedAt(insightCard.getLastViewedAt())
                         .updatedAt(insightCard.getLastModifiedDate())
                         .build())
-                .toList();
+                .collect(Collectors.toList());
+
+        return GetInsightCardResponse.builder()
+                .totalAmount(totalWorkCardAmount)
+                .cards(workCardList)
+                .build();
     }
 
     public List<GetAllInsightCardResponse> getTop4LastViewedAtInsightCards(CardType cardType, Authentication authentication) {
@@ -121,9 +142,7 @@ public class InsightCardService {
     @Transactional
     public void deleteInsightCard(Long cardId, Authentication authentication) {
         User currentUser = getAuthenticatedUser(authentication);
-
         InsightCard insightCard = findOwnedInsightCard(currentUser.getId(), cardId);
-
         insightCardRepository.delete(insightCard);
     }
 

--- a/src/main/java/welkit_server/domain/mail/service/EmailService.java
+++ b/src/main/java/welkit_server/domain/mail/service/EmailService.java
@@ -48,6 +48,7 @@ public class EmailService {
                 mimeMessage.setRecipients(Message.RecipientType.TO, emailMessage.getTo());
                 mimeMessage.setSubject(emailMessage.getSubject());
                 mimeMessage.setText("인증번호: " + authNum, "utf-8");
+                mimeMessage.setFrom("no-reply@welkit.kr");
                 mailSender.send(mimeMessage);
                 redisTemplate.opsForValue().set(RedisKey.EMAIL_CODE.getKey(emailMessage.getTo()), authNum, RedisKey.EMAIL_CODE.getTtl() );
             }

--- a/src/main/java/welkit_server/domain/terms/controller/TermController.java
+++ b/src/main/java/welkit_server/domain/terms/controller/TermController.java
@@ -29,13 +29,15 @@ public class TermController {
     @GetMapping
     public ResponseEntity<SuccessResponse<?>> getTerms(
             @RequestParam(value = "categoryId", required = false) Long categoryId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
             Authentication authentication
     ) {
         if(categoryId != null){
-            List<GetCategoryTermResponse> terms = termService.getCategoryTerms(categoryId,authentication);
+            List<GetCategoryTermResponse> terms = termService.getCategoryTerms(categoryId,page,size,authentication);
             return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, terms));
         } else {
-            List<GetAllTermResponse> terms = termService.getTerms(authentication);
+            List<GetAllTermResponse> terms = termService.getTerms(page,size,authentication);
             return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, terms));
         }
     }

--- a/src/main/java/welkit_server/domain/terms/controller/TermController.java
+++ b/src/main/java/welkit_server/domain/terms/controller/TermController.java
@@ -12,7 +12,7 @@ import welkit_server.domain.terms.dto.request.EditTermRequest;
 import welkit_server.domain.terms.dto.response.EditTermResponse;
 import welkit_server.domain.terms.dto.response.CreateTermResponse;
 import welkit_server.domain.terms.dto.response.GetAllTermResponse;
-import welkit_server.domain.terms.dto.response.GetCategoryTermResponse;
+import welkit_server.domain.terms.dto.response.TermsResponse;
 import welkit_server.domain.terms.service.TermService;
 import welkit_server.global.dto.SuccessResponse;
 import welkit_server.global.exception.message.SuccessMessage;
@@ -27,17 +27,17 @@ public class TermController {
 
     @Operation(summary = "용어 조회", description = "등록된 용어를 조회합니다")
     @GetMapping
-    public ResponseEntity<SuccessResponse<?>> getTerms(
-            @RequestParam(value = "categoryId", required = false) Long categoryId,
+    public ResponseEntity<SuccessResponse<TermsResponse>> getTerms(
+            @RequestParam(value = "categoryIds", required = false) List<Long> categoryIds,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             Authentication authentication
     ) {
-        if(categoryId != null){
-            List<GetCategoryTermResponse> terms = termService.getCategoryTerms(categoryId,page,size,authentication);
-            return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, terms));
+        if(categoryIds != null){
+            TermsResponse termFindByCategory = termService.getCategoryTerms(page,size,categoryIds, authentication);
+            return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, termFindByCategory));
         } else {
-            List<GetAllTermResponse> terms = termService.getTerms(page,size,authentication);
+            TermsResponse terms = termService.getTerms(page,size,authentication);
             return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, terms));
         }
     }

--- a/src/main/java/welkit_server/domain/terms/dto/response/TermsResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/TermsResponse.java
@@ -2,15 +2,13 @@ package welkit_server.domain.terms.dto.response;
 
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class GetCategoryTermResponse {
-
-    private Long termId;
-    private String name;
-    private String definition;
-    private Long categoryId;
-
+public class TermsResponse {
+    private Long totalAmount;
+    private List<GetAllTermResponse> terms;
 }

--- a/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
@@ -1,12 +1,13 @@
 package welkit_server.domain.terms.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import welkit_server.domain.terms.entity.Term;
 import welkit_server.domain.user.entity.User;
-import java.util.List;
 
 @Repository
 public interface TermRepository extends JpaRepository<Term, Long> {
@@ -14,11 +15,11 @@ public interface TermRepository extends JpaRepository<Term, Long> {
     @Query("SELECT t FROM Term t " +
             "WHERE t.user = :user " +
             "ORDER BY t.createdDate DESC")
-    List<Term> findAllByUser(@Param("user") User user);
+    Page<Term> findAllByUser(@Param("user") User user, Pageable pageable);
 
     @Query("SELECT t FROM Term t " +
             "WHERE t.user = :user AND t.category.id = :categoryId  " +
             "ORDER BY t.createdDate DESC")
-    List<Term> findAllByUserAndCategoryId(@Param("user") User user, @Param("categoryId") Long categoryId);
+    Page<Term> findAllByUserAndCategoryId(@Param("user") User user, @Param("categoryId") Long categoryId, Pageable pageable);
 
 }

--- a/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
@@ -9,17 +9,30 @@ import org.springframework.stereotype.Repository;
 import welkit_server.domain.terms.entity.Term;
 import welkit_server.domain.user.entity.User;
 
+import java.util.List;
+
 @Repository
 public interface TermRepository extends JpaRepository<Term, Long> {
 
     @Query("SELECT t FROM Term t " +
             "WHERE t.user = :user " +
             "ORDER BY t.createdDate DESC")
-    Page<Term> findAllByUser(@Param("user") User user, Pageable pageable);
+    Page<Term> findByUserOrderByCreatedDateDesc(@Param("user") User user, Pageable pageable);
 
     @Query("SELECT t FROM Term t " +
-            "WHERE t.user = :user AND t.category.id = :categoryId  " +
+            "WHERE t.user = :user " +
+            "AND t.category.id IN :categoryIds  " +
             "ORDER BY t.createdDate DESC")
-    Page<Term> findAllByUserAndCategoryId(@Param("user") User user, @Param("categoryId") Long categoryId, Pageable pageable);
+    Page<Term> findAllByUserAndCategoryIds(
+            @Param("user") User user,
+            @Param("categoryIds") List<Long>categoryIds,
+            Pageable pageable);
+
+    long countByUser(User user);
+
+    @Query("SELECT COUNT(t) FROM Term t " +
+            "WHERE t.user = :user " +
+            "AND t.category.id IN :categoryIds")
+    long countByUserAndCategoryIds(@Param("user") User user, @Param("categoryIds") List<Long> categoryIds);
 
 }

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -12,7 +12,7 @@ import welkit_server.domain.terms.dto.request.EditTermRequest;
 import welkit_server.domain.terms.dto.response.EditTermResponse;
 import welkit_server.domain.terms.dto.response.CreateTermResponse;
 import welkit_server.domain.terms.dto.response.GetAllTermResponse;
-import welkit_server.domain.terms.dto.response.GetCategoryTermResponse;
+import welkit_server.domain.terms.dto.response.TermsResponse;
 import welkit_server.domain.terms.entity.Term;
 import welkit_server.domain.terms.entity.TermCategory;
 import welkit_server.domain.terms.repository.TermCategoryRepository;
@@ -37,13 +37,15 @@ public class TermService {
     private final TermCategoryRepository termCategoryRepository;
     private final TermCategoryService termCategoryService;
 
-    public List<GetAllTermResponse> getTerms(int page, int size, Authentication authentication) {
+    public TermsResponse getTerms(int page, int size, Authentication authentication) {
         User user = getAuthenticatedUser(authentication);
         Pageable pageable = PageRequest.of(page,size);
 
-        Page<Term> termList = termRepository.findAllByUser(user,pageable);
+        Page<Term> termList = termRepository.findByUserOrderByCreatedDateDesc(user,pageable);
 
-        return termList.getContent().stream()
+        long totalCount = termRepository.countByUser(user);
+
+        List<GetAllTermResponse> terms =  termList.getContent().stream()
                 .map(term -> GetAllTermResponse.builder()
                         .termId(term.getId())
                         .name(term.getName())
@@ -52,23 +54,43 @@ public class TermService {
                         .updatedAt(term.getLastModifiedDate())
                         .build())
                 .toList();
+
+        return TermsResponse.builder()
+                .totalAmount(totalCount)
+                .terms(terms)
+                .build();
     }
 
-    public List<GetCategoryTermResponse> getCategoryTerms(Long categoryId, int page, int size, Authentication authentication){
+    public TermsResponse getCategoryTerms( int page, int size, List<Long> categoryIds, Authentication authentication){
         User user = getAuthenticatedUser(authentication);
-        termCategoryRepository.findByIdAndUser(categoryId, user)
-                .orElseThrow(() -> new BadRequestException(ErrorMessage.WK_ENUM_VALUE_BAD_REQUEST));
-        Pageable pageable = PageRequest.of(page,size);
-        Page<Term> sortedCategoryTerms = termRepository. findAllByUserAndCategoryId(user,categoryId,pageable);
 
-        return sortedCategoryTerms.stream()
-                .map(term -> GetCategoryTermResponse.builder()
+        List<Long> validCategoryIds = categoryIds.stream()
+                .filter(id -> termCategoryRepository.findByIdAndUser(id, user).isPresent())
+                .toList();
+
+        if (validCategoryIds.isEmpty()) {
+            throw new BadRequestException(ErrorMessage.WK_ENUM_VALUE_BAD_REQUEST);
+        }
+        Pageable pageable = PageRequest.of(page,size);
+        Page<Term> sortedCategoryTerms =
+                termRepository.findAllByUserAndCategoryIds(user, validCategoryIds, pageable);
+
+        long categoryCount = termRepository.countByUserAndCategoryIds(user, validCategoryIds);
+
+        List<GetAllTermResponse> categorySortedTerms = sortedCategoryTerms.stream()
+                .map(term -> GetAllTermResponse.builder()
                         .termId(term.getId())
                         .name(term.getName())
                         .definition(term.getDefinition())
                         .categoryId(term.getCategory().getId())
                         .build())
                 .toList();
+
+        return TermsResponse.builder()
+                .totalAmount(categoryCount)
+                .terms(categorySortedTerms)
+                .build();
+
     }
 
     @Transactional

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -1,6 +1,9 @@
 package welkit_server.domain.terms.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,12 +37,13 @@ public class TermService {
     private final TermCategoryRepository termCategoryRepository;
     private final TermCategoryService termCategoryService;
 
-    public List<GetAllTermResponse> getTerms(Authentication authentication) {
+    public List<GetAllTermResponse> getTerms(int page, int size, Authentication authentication) {
         User user = getAuthenticatedUser(authentication);
+        Pageable pageable = PageRequest.of(page,size);
 
-        List<Term> termList = termRepository.findAllByUser(user);
+        Page<Term> termList = termRepository.findAllByUser(user,pageable);
 
-        return termList.stream()
+        return termList.getContent().stream()
                 .map(term -> GetAllTermResponse.builder()
                         .termId(term.getId())
                         .name(term.getName())
@@ -50,12 +54,12 @@ public class TermService {
                 .toList();
     }
 
-    public List<GetCategoryTermResponse> getCategoryTerms(Long categoryId, Authentication authentication){
+    public List<GetCategoryTermResponse> getCategoryTerms(Long categoryId, int page, int size, Authentication authentication){
         User user = getAuthenticatedUser(authentication);
         termCategoryRepository.findByIdAndUser(categoryId, user)
                 .orElseThrow(() -> new BadRequestException(ErrorMessage.WK_ENUM_VALUE_BAD_REQUEST));
-
-        List<Term> sortedCategoryTerms = termRepository. findAllByUserAndCategoryId(user, categoryId);
+        Pageable pageable = PageRequest.of(page,size);
+        Page<Term> sortedCategoryTerms = termRepository. findAllByUserAndCategoryId(user,categoryId,pageable);
 
         return sortedCategoryTerms.stream()
                 .map(term -> GetCategoryTermResponse.builder()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,11 +2,12 @@ spring:
   profiles:
     active: local
   mail:
-    host: smtp.gmail.com
-    port: 587
+    host: smtp.worksmobile.com
+    port: 465
     properties:
       mail.smtp.auth: true
       mail.smtp.timeout: 5000
-      mail.smtp.starttls.enable: true
+      mail.smtp.ssl.enable: true
+      mail.smtp.ssl.trust: smtp.worksmobile.com
 blocked:
   email-domains: []


### PR DESCRIPTION
## 🔥 Related Issues
- close #41 

## ✅ 작업 리스트
- [x] 용어 사전 전체 조회 및 카테고리별 조회 결과 페이징 적용
- [x] 용어 사전 카테고리 다중 선택 조회 및 응답 필드에 데이터 수 추가
- [x] 인사이트 카드 조회 결과 페이징 적용 및 전체 데이터 수 응답 필드 추가
- [x] 이메일 인증 로직 수정

## 🔧 작업 내용
### 용어 사전 조회
- 전체 조회 및 카테고리별 조회 시 페이징 적용 (1 page - 10개 최대)
- 다중 카테고리 선택 / 조회 가능하도록 카테고리 조회 로직 수정
- 존재하지않는 카테고리 선택 과 존재하는 카테고리 선택 둘다 하면 존재하는 카테고리의 데이터만 반환 
- 둘다 존재하지않는 카테고리일때는 예외처리 
- 카테고리는 하나 이상 선택 가능 
- 전체 데이터 수 및 카테고리별 조회 데이터 수 응답 필드에 포함
### 인사이트 카드 조회
- 인사이트 카드 전체 조회시 페이징 적용 (1page - 10개 최대)
- 전체 데이터 수를 응답 필드에 포함
### 이메일 인증
- 인증 로직 수정 ( Google WorkSpace -> Naver WorkSpace)
## 🤔 궁금한점

## 📸 ScreenShot