### PR TITLE
인사이트 카드 즐겨찾기 조회 API 구현 및 즐겨찾기 수 응답 필드 추가

### DIFF
--- a/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
+++ b/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import welkit_server.domain.insightcard.dto.request.InsightCardRequest;
 import welkit_server.domain.insightcard.dto.response.GetAllInsightCardResponse;
+import welkit_server.domain.insightcard.dto.response.GetFavoriteInsightCardResponse;
 import welkit_server.domain.insightcard.dto.response.InsightCardResponse;
 import welkit_server.domain.insightcard.model.CardType;
 import welkit_server.domain.insightcard.service.InsightCardService;
@@ -46,6 +47,18 @@ public class InsightCardController {
         List<GetAllInsightCardResponse> recentInsightCard = insightCardService.getTop4LastViewedAtInsightCards(CardType.PERSON, authentication);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, recentInsightCard));
     }
+
+    @Operation(summary = "인물 카드 즐겨찾기 등록된 카드 조회", description = "사용자가 즐겨찾기에 등록한 인물 카드를 조회합니다 ")
+    @GetMapping("/person/favorites")
+    public ResponseEntity<SuccessResponse<GetFavoriteInsightCardResponse>> getFavoriteInsightPersonCard(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Authentication authentication
+    ) {
+        GetFavoriteInsightCardResponse favoritePersonInsightCards  = insightCardService.getFavoritePersonInsightCards(page, size, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, favoritePersonInsightCards));
+    }
+
 
     @Operation(summary = "인물 카드 생성", description = "새로운 인물 카드를 생성합니다")
     @PostMapping("/person")
@@ -102,6 +115,17 @@ public class InsightCardController {
     public ResponseEntity<SuccessResponse<GetAllInsightCardResponse>> getRecentInsightWorkCard(Authentication authentication) {
         List<GetAllInsightCardResponse> recentInsightCard = insightCardService.getTop4LastViewedAtInsightCards(CardType.WORK, authentication);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, recentInsightCard));
+    }
+
+    @Operation(summary = "인물 카드 즐겨찾기 등록된 카드 조회", description = "사용자가 즐겨찾기에 등록한 인물 카드를 조회합니다 ")
+    @GetMapping("/work/favorites")
+    public ResponseEntity<SuccessResponse<GetFavoriteInsightCardResponse>> getFavoriteInsightWorkCard(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Authentication authentication
+    ) {
+        GetFavoriteInsightCardResponse favoriteWorkInsightCards  = insightCardService.getFavoriteWorkInsightCards(page, size, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, favoriteWorkInsightCards));
     }
 
     @Operation(summary = "업무 카드 생성", description = "새로운 업무 카드를 생성합니다")

--- a/src/main/java/welkit_server/domain/insightcard/dto/response/GetFavoriteInsightCardResponse.java
+++ b/src/main/java/welkit_server/domain/insightcard/dto/response/GetFavoriteInsightCardResponse.java
@@ -1,0 +1,17 @@
+package welkit_server.domain.insightcard.dto.response;
+import lombok.*;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class GetFavoriteInsightCardResponse {
+
+    private Long favoriteTotal;
+    private List<GetAllInsightCardResponse> cards;
+
+}
+
+
+

--- a/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
+++ b/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
@@ -1,5 +1,7 @@
 package welkit_server.domain.insightcard.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +25,17 @@ public interface InsightCardRepository extends JpaRepository<InsightCard, Long> 
     List<InsightCard> findAllInsightWorkCards(@Param("user") User user);
 
     List<InsightCard> findTop4ByUserIdAndTypeAndLastViewedAtIsNotNullOrderByLastViewedAtDesc(Long userId, CardType type);
+
+    @Query("SELECT i FROM InsightCard i " +
+            "WHERE i.user = :user AND i.type ='PERSON' AND i.isFavorite = true " +
+            "ORDER BY i.updatedAt DESC")
+    Page<InsightCard> findFavoritePersonCards(@Param("user") User user, Pageable pageable);
+
+    @Query("SELECT i FROM InsightCard i " +
+            "WHERE i.user = :user AND i.type ='WORK' AND i.isFavorite = true " +
+            "ORDER BY i.updatedAt DESC")
+    Page<InsightCard> findFavoriteWorkCards(@Param("user") User user, Pageable pageable);
+
+    long countByUserAndTypeAndIsFavoriteTrue(User user, CardType type);
+
 }

--- a/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
+++ b/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
@@ -1,11 +1,15 @@
 package welkit_server.domain.insightcard.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.insightcard.dto.request.InsightCardRequest;
 import welkit_server.domain.insightcard.dto.response.GetAllInsightCardResponse;
+import welkit_server.domain.insightcard.dto.response.GetFavoriteInsightCardResponse;
 import welkit_server.domain.insightcard.dto.response.InsightCardResponse;
 import welkit_server.domain.insightcard.entity.InsightCard;
 import welkit_server.domain.insightcard.model.CardType;
@@ -92,6 +96,60 @@ public class InsightCardService {
         insightCard.updateLastViewedAt();
 
         return InsightCardResponse.fromEntity(insightCard);
+    }
+
+    public GetFavoriteInsightCardResponse getFavoritePersonInsightCards(int page, int size, Authentication authentication) {
+        User currentUser = getAuthenticatedUser(authentication);
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<InsightCard> favoritePersonInsightCard = insightCardRepository.findFavoritePersonCards(currentUser, pageable);
+
+        long totalFavoritePersonCardAmount = insightCardRepository.countByUserAndTypeAndIsFavoriteTrue(currentUser,CardType.PERSON);
+
+        List<GetAllInsightCardResponse> favoritePersonInsightCards = favoritePersonInsightCard.stream()
+                .map(insightPersonCards-> GetAllInsightCardResponse.builder()
+                        .cardId(insightPersonCards.getId())
+                        .title(insightPersonCards.getTitle())
+                        .description(insightPersonCards.getDescription())
+                        .note(insightPersonCards.getNote())
+                        .type(insightPersonCards.getType())
+                        .favorite(insightPersonCards.isFavorite())
+                        .lastViewedAt(insightPersonCards.getLastViewedAt())
+                        .updatedAt(insightPersonCards.getLastModifiedDate())
+                        .build())
+                .toList();
+
+        return GetFavoriteInsightCardResponse.builder()
+                .favoriteTotal(totalFavoritePersonCardAmount)
+                .cards(favoritePersonInsightCards)
+                .build();
+    }
+
+    public GetFavoriteInsightCardResponse getFavoriteWorkInsightCards(int page, int size, Authentication authentication) {
+        User currentUser = getAuthenticatedUser(authentication);
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<InsightCard> favoriteWorkInsightCard = insightCardRepository.findFavoriteWorkCards(currentUser, pageable);
+
+        long totalFavoriteWorkCardAmount = insightCardRepository.countByUserAndTypeAndIsFavoriteTrue(currentUser,CardType.WORK);
+
+        List<GetAllInsightCardResponse> favoriteWorkInsightCards =  favoriteWorkInsightCard.stream()
+                .map(insightWorkCards-> GetAllInsightCardResponse.builder()
+                        .cardId(insightWorkCards.getId())
+                        .title(insightWorkCards.getTitle())
+                        .description(insightWorkCards.getDescription())
+                        .note(insightWorkCards.getNote())
+                        .type(insightWorkCards.getType())
+                        .favorite(insightWorkCards.isFavorite())
+                        .lastViewedAt(insightWorkCards.getLastViewedAt())
+                        .updatedAt(insightWorkCards.getLastModifiedDate())
+                        .build())
+                .toList();
+
+        return GetFavoriteInsightCardResponse.builder()
+                .favoriteTotal(totalFavoriteWorkCardAmount)
+                .cards(favoriteWorkInsightCards)
+                .build();
     }
 
     @Transactional


### PR DESCRIPTION
## 🔥 Related Issues
- close #40 

## ✅ 작업 리스트
- [x] 인사이트 카드 즐겨찾기 데이터 수 계산 SQL 작성
- [x] 인사이트 카드 즐겨찾기한 데이터만 조회 API 구현
- [ ] 인사이트 카드 즐겨찾기 조회 결과 응답 DTO 추가
## 🔧 작업 내용
- 인사이트 카드 즐겨찾기한 카드만 조회하도록 API 구현
- 즐겨찾기 카드를 조회할때 즐겨찾기한 데이터의 수를 함께 반환
## 🤔 궁금한점

## 📸 ScreenShot
