### PR TITLE
데이터 입력 허용 범위 설정

### DIFF
--- a/src/main/java/welkit_server/domain/admin/dto/request/NoticeAdminRequest.java
+++ b/src/main/java/welkit_server/domain/admin/dto/request/NoticeAdminRequest.java
@@ -12,9 +12,11 @@ import welkit_server.domain.admin.model.NoticePriority;
 public class NoticeAdminRequest {
 
     @NotBlank
+    @Size(min = 1, max = 30)
     private String title;
 
     @NotBlank
+    @Size(min = 1, max = 2000)
     private String content;
 
     @NotNull

--- a/src/main/java/welkit_server/domain/admin/entity/Notice.java
+++ b/src/main/java/welkit_server/domain/admin/entity/Notice.java
@@ -18,10 +18,10 @@ public class Notice extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 30)
     private String title;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, length = 2000)
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/welkit_server/domain/community/dto/request/CommentCreateRequest.java
+++ b/src/main/java/welkit_server/domain/community/dto/request/CommentCreateRequest.java
@@ -1,6 +1,7 @@
 package welkit_server.domain.community.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CommentCreateRequest {
     @NotBlank
+    @Size(min = 1, max = 200)
     private String content;
     private Long parentId;
 }

--- a/src/main/java/welkit_server/domain/community/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/welkit_server/domain/community/dto/request/CommentUpdateRequest.java
@@ -1,5 +1,6 @@
 package welkit_server.domain.community.dto.request;
 
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CommentUpdateRequest {
+    @Size(min = 1, max = 200)
     private String content;
 }

--- a/src/main/java/welkit_server/domain/community/dto/request/PostCreateRequest.java
+++ b/src/main/java/welkit_server/domain/community/dto/request/PostCreateRequest.java
@@ -2,6 +2,7 @@ package welkit_server.domain.community.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,9 @@ public class PostCreateRequest {
     @NotNull
     private JobRole jobRole;
     @NotBlank
+    @Size(min = 1, max = 30)
     private String title;
     @NotBlank
+    @Size(min = 1, max = 2000)
     private String content;
 }

--- a/src/main/java/welkit_server/domain/community/dto/request/PostUpdateRequest.java
+++ b/src/main/java/welkit_server/domain/community/dto/request/PostUpdateRequest.java
@@ -2,6 +2,7 @@ package welkit_server.domain.community.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,9 @@ public class PostUpdateRequest {
     @NotNull
     private JobRole jobRole;
     @NotBlank
+    @Size(min = 1, max = 30)
     private String title;
     @NotBlank
+    @Size(min = 1, max = 2000)
     private String content;
 }

--- a/src/main/java/welkit_server/domain/community/entity/CommunityComments.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityComments.java
@@ -29,7 +29,7 @@ public class CommunityComments extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
+    @Column(nullable = false, length = 200)
     private String comment;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/welkit_server/domain/community/entity/CommunityPosts.java
+++ b/src/main/java/welkit_server/domain/community/entity/CommunityPosts.java
@@ -24,10 +24,10 @@ public class CommunityPosts extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable=false, length = 50)
+    @Column(nullable=false, length = 30)
     private String title;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(nullable=false, length = 2000)
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/welkit_server/domain/insightcard/dto/request/InsightCardRequest.java
+++ b/src/main/java/welkit_server/domain/insightcard/dto/request/InsightCardRequest.java
@@ -11,11 +11,14 @@ import welkit_server.domain.insightcard.model.CardType;
 public class InsightCardRequest {
 
     @NotBlank
+    @Size(min = 1, max = 30)
     private String title;
 
     @NotBlank
+    @Size(min = 1, max = 500)
     private String description;
 
+    @Size(max = 200)
     private String note;
 
     @NotNull

--- a/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
+++ b/src/main/java/welkit_server/domain/insightcard/entity/InsightCard.java
@@ -20,13 +20,13 @@ public class InsightCard extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 30)
     private String title;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, length = 500)
     private String description;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(length = 200)
     private String note;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/welkit_server/domain/retrospectives/dto/request/RetrospectiveRequest.java
+++ b/src/main/java/welkit_server/domain/retrospectives/dto/request/RetrospectiveRequest.java
@@ -14,12 +14,14 @@ import java.time.LocalDate;
 public class RetrospectiveRequest {
 
     @NotBlank
+    @Size(min = 1, max = 30)
     private String title;
 
     @NotNull
     private Type type;
 
     @NotBlank
+    @Size(min = 1, max = 2000)
     private String content;
 
     @NotNull

--- a/src/main/java/welkit_server/domain/retrospectives/entity/Retrospective.java
+++ b/src/main/java/welkit_server/domain/retrospectives/entity/Retrospective.java
@@ -20,10 +20,10 @@ public class Retrospective extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 30)
     private String title;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
+    @Column(nullable = false, length = 2000)
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
+++ b/src/main/java/welkit_server/domain/terms/dto/request/CreateTermRequest.java
@@ -1,6 +1,7 @@
 package welkit_server.domain.terms.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 import welkit_server.domain.terms.entity.*;
 
@@ -11,13 +12,16 @@ import welkit_server.domain.terms.entity.*;
 public class CreateTermRequest {
 
     @NotBlank
+    @Size(min = 1, max = 50)
     private String name;
 
     @NotBlank
+    @Size(min = 1, max = 500)
     private String definition;
 
     private Long categoryId;
 
+    @Size(min = 1, max = 20)
     private String categoryName;
 
     public Term toEntity(TermCategory category) {

--- a/src/main/java/welkit_server/domain/terms/dto/request/EditTermRequest.java
+++ b/src/main/java/welkit_server/domain/terms/dto/request/EditTermRequest.java
@@ -1,6 +1,7 @@
 package welkit_server.domain.terms.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Getter
@@ -9,13 +10,16 @@ import lombok.*;
 @Builder
 public class EditTermRequest {
 
+    @Size(min = 1, max = 50)
     private String name;
 
+    @Size(min = 1, max = 500)
     private String definition;
 
     @NotNull
     private Long categoryId;
 
+    @Size(min = 1, max = 20)
     private String categoryName;
 
 }

--- a/src/main/java/welkit_server/domain/terms/entity/Term.java
+++ b/src/main/java/welkit_server/domain/terms/entity/Term.java
@@ -21,7 +21,7 @@ public class Term extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String name;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, length = 500)
     private String definition;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
+++ b/src/main/java/welkit_server/domain/terms/entity/TermCategory.java
@@ -17,7 +17,7 @@ public class TermCategory extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 50)
+    @Column(nullable = false, unique = true, length = 20)
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/welkit_server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/welkit_server/global/exception/GlobalExceptionHandler.java
@@ -49,7 +49,6 @@ public class GlobalExceptionHandler {
             final MethodArgumentNotValidException e) {
 
         FieldError fieldError = e.getBindingResult().getFieldError();
-
         ErrorMessage errorMessage;
 
         if (fieldError == null) {
@@ -58,21 +57,57 @@ public class GlobalExceptionHandler {
             String rejectedValue = String.valueOf(fieldError.getRejectedValue());
 
             if (rejectedValue.length() < 8) {
-                errorMessage = ErrorMessage.INVALID_PASSWORD_MIN_LENGTH; // 최소 8자
+                errorMessage = ErrorMessage.INVALID_PASSWORD_MIN_LENGTH;
             } else if (rejectedValue.length() > 64) {
-                errorMessage = ErrorMessage.INVALID_PASSWORD_MAX_LENGTH; // 최대 64자
+                errorMessage = ErrorMessage.INVALID_PASSWORD_MAX_LENGTH;
             } else if (!rejectedValue.matches(".*[0-9].*")) {
-                errorMessage = ErrorMessage.INVALID_PASSWORD_NUMBER; // 숫자 포함
+                errorMessage = ErrorMessage.INVALID_PASSWORD_NUMBER;
             } else if (!rejectedValue.matches(".*[!@#$%^&*(),.?\":{}|<>\\-_=+\\[\\]{};:'\",.<>/?].*")) {
-                errorMessage = ErrorMessage.INVALID_PASSWORD_SPECIAL_CHAR; // 특수문자 포함
+                errorMessage = ErrorMessage.INVALID_PASSWORD_SPECIAL_CHAR;
             } else {
                 errorMessage = ErrorMessage.WK_VALIDATION_MISSING;
             }
+        } else if ("Size".equals(fieldError.getCode())) {
+            String field = fieldError.getField();
+            String rejectedValue = fieldError.getRejectedValue() != null
+                    ? fieldError.getRejectedValue().toString() : "";
+
+            errorMessage = switch (field) {
+                // 용어 이름 / 정의
+                case "name" -> rejectedValue.length() > 50
+                        ? ErrorMessage.TERM_NAME_MAX_LENGTH
+                        : ErrorMessage.TERM_NAME_MIN_LENGTH;
+                case "definition" -> rejectedValue.length() > 500
+                        ? ErrorMessage.TERM_DEFINITION_MAX_LENGTH
+                        : ErrorMessage.TERM_DEFINITION_MIN_LENGTH;
+
+                // 인사이트 카드
+                case "title" -> rejectedValue.length() > 30
+                        ? ErrorMessage.INSIGHT_CARD_TITLE_MAX_LENGTH
+                        : ErrorMessage.INSIGHT_CARD_TITLE_MIN_LENGTH;
+                case "description" -> rejectedValue.length() > 500
+                        ? ErrorMessage.INSIGHT_CARD_DESCRIPTION_MAX_LENGTH
+                        : ErrorMessage.INSIGHT_CARD_DESCRIPTION_MIN_LENGTH;
+                case "note" -> rejectedValue.length() > 200
+                        ? ErrorMessage.INSIGHT_CARD_NOTE_MAX_LENGTH
+                        : ErrorMessage.INSIGHT_CARD_NOTE_MIN_LENGTH;
+
+                // 회고
+                case "content" -> rejectedValue.length() > 2000
+                        ? ErrorMessage.RETROSPECTIVE_CONTENT_MAX_LENGTH
+                        : ErrorMessage.RETROSPECTIVE_CONTENT_MIN_LENGTH;
+
+                // 카테고리 이름
+                case "categoryName" -> rejectedValue.length() > 20
+                        ? ErrorMessage.CATEGORY_NAME_MAX_LENGTH
+                        : ErrorMessage.CATEGORY_NAME_MIN_LENGTH;
+
+                default -> ErrorMessage.WK_VALIDATION_LENGTH_EXCEEDED;
+            };
         } else {
             errorMessage = switch (fieldError.getCode()) {
                 case "NotNull", "NotBlank" -> ErrorMessage.WK_VALIDATION_NULL_OR_BLANK;
                 case "Email" -> ErrorMessage.WK_VALIDATION_EMAIL;
-                case "Size" -> ErrorMessage.WK_VALIDATION_LENGTH_EXCEEDED;
                 default -> ErrorMessage.WK_VALIDATION_MISSING;
             };
         }
@@ -80,8 +115,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(errorMessage.getStatus())
                 .body(ErrorResponse.of(errorMessage));
     }
-
-
+    
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(final HttpMessageNotReadableException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
+++ b/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
@@ -22,7 +22,6 @@ public enum ErrorMessage {
     INVALID_CREDENTIAL(400, "USR1001", "이메일 또는 비밀번호가 일치하지 않습니다."),
     USER_NOT_FOUND(404, "USR1002", "사용자를 찾을 수 없습니다."),
 
-
     // 회원가입 (USR)
     DUPLICATE_EMAIL(400, "USR2001", "이미 사용중인 이메일 주소입니다."),
     INVALID_EMAIL_CODE(400, "USR2002", "이메일 인증 코드가 올바르지 않습니다."),
@@ -32,13 +31,27 @@ public enum ErrorMessage {
 
     // 용어 사전 (TRM)
     TERM_NOT_FOUND(404, "TRM1001", "해당 용어를 찾을 수 없습니다."),
+    TERM_NAME_MIN_LENGTH(400, "TRM1002", "용어 이름은 최소 1자 이상이어야 합니다."),
+    TERM_NAME_MAX_LENGTH(400, "TRM1003", "용어 이름은 최대 50자를 초과할 수 없습니다."),
+    TERM_DEFINITION_MIN_LENGTH(400, "TRM1004", "용어 정의는 최소 1자 이상이어야 합니다."),
+    TERM_DEFINITION_MAX_LENGTH(400, "TRM1005", "용어 정의는 최대 500자를 초과할 수 없습니다."),
+    CATEGORY_NAME_MIN_LENGTH(400, "TRM1006", "카테고리 이름은 최소 1자 이상이어야 합니다."),
+    CATEGORY_NAME_MAX_LENGTH(400, "TRM1007", "카테고리 이름은 최대 20자를 초과할 수 없습니다."),
 
     // 인사이트 카드 (INS)
     INSIGHT_CARD_NOT_FOUND(404, "INS1001", "해당 카드를 찾을 수 없습니다."),
+    INSIGHT_CARD_TITLE_MIN_LENGTH(400, "INS1002", "카드 제목은 최소 1자 이상이어야 합니다."),
+    INSIGHT_CARD_TITLE_MAX_LENGTH(400, "INS1003", "카드 제목은 최대 30자를 초과할 수 없습니다."),
+    INSIGHT_CARD_DESCRIPTION_MIN_LENGTH(400, "INS1004", "카드 설명은 최소 1자 이상이어야 합니다."),
+    INSIGHT_CARD_DESCRIPTION_MAX_LENGTH(400, "INS1005", "카드 설명은 최대 500자를 초과할 수 없습니다."),
+    INSIGHT_CARD_NOTE_MIN_LENGTH(400, "INS1006", "카드 비고는 최소 0자 이상이어야 합니다."),
+    INSIGHT_CARD_NOTE_MAX_LENGTH(400, "INS1007", "카드 비고는 최대 200자를 초과할 수 없습니다."),
 
     // 회고 (RET)
     RETROSPECTIVE_NOT_FOUND(404, "RET1001", "해당 회고를 찾을 수 없습니다."),
-    RETROSPECTIVE_INVALID_DATE_RANGE(400, "RET1002", "회고의 날짜 범위가 올바르지 않습니다."),
+    RETROSPECTIVE_CONTENT_MIN_LENGTH(400, "RET1002", "회고 내용은 최소 1자 이상이어야 합니다."),
+    RETROSPECTIVE_CONTENT_MAX_LENGTH(400, "RET1003", "회고 내용은 최대 2000자를 초과할 수 없습니다."),
+    RETROSPECTIVE_INVALID_DATE_RANGE(400, "RET1004", "회고의 날짜 범위가 올바르지 않습니다."),
 
     // 커뮤니티 (CMN)
     COMMUNITY_POST_NOT_FOUND(404, "CMN1001", "해당 게시글을 찾을 수 없습니다."),


### PR DESCRIPTION
## 🔥 Related Issues
- close #46

## ✅ 작업 리스트
- [x] 커뮤니티 DTO/Entity 필드 유효성 범위 수정
- [x] 회고 DTO/Entity 필드 유효성 범위 수정
- [x] 인사이트 카드 DTO/Entity 필드 유효성 범위 수정
- [x] 용어/카테고리 DTO/Entity 필드 유효성 범위 수정
- [x] 공지사항 DTO/Entity 필드 유효성 범위 수정
- [x] 글로벌 예외 처리 및 에러 메시지 최신화

## 🔧 작업 내용
- DTO와 Entity에서 각 필드의 허용 범위를 검증하도록 수정
- 공통/로그인/회원가입/마이페이지/회고/커뮤니티/용어/인사이트 카드 등 에러 메시지 최신화
- 글로벌 예외 처리 로직 개선

## 🤔 궁금한점
- 필드 유효성 범위 수정으로 인한 기존 데이터 마이그레이션 필요?