### PR TITLE
용어 사전 카테고리 조회 로직 에러 수정

### DIFF
--- a/src/main/java/welkit_server/domain/terms/controller/TermController.java
+++ b/src/main/java/welkit_server/domain/terms/controller/TermController.java
@@ -28,18 +28,24 @@ public class TermController {
     @Operation(summary = "용어 조회", description = "등록된 용어를 조회합니다")
     @GetMapping
     public ResponseEntity<SuccessResponse<TermsResponse>> getTerms(
-            @RequestParam(value = "categoryIds", required = false) List<Long> categoryIds,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             Authentication authentication
     ) {
-        if(categoryIds != null){
-            TermsResponse termFindByCategory = termService.getCategoryTerms(page,size,categoryIds, authentication);
-            return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, termFindByCategory));
-        } else {
-            TermsResponse terms = termService.getTerms(page,size,authentication);
-            return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, terms));
-        }
+        TermsResponse termsFindAll = termService.getTerms(page,size,authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, termsFindAll));
+    }
+
+    @Operation(summary = "카테고리별 용어 조회", description = "사용자가 선택한 카테고리에 맞게 용어를 조회합니다")
+    @GetMapping("/category")
+    public ResponseEntity<SuccessResponse<TermsResponse>> getCategoryTerms(
+            @RequestParam(value = "categoryId", required = false) List<Long> categoryId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Authentication authentication
+    ) {
+        TermsResponse termsFindByCategory = termService.getTermsByCategory(page,size,categoryId, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, termsFindByCategory));
     }
 
     @Operation(summary = "용어 등록", description = "새로운 용어를 등록합니다")

--- a/src/main/java/welkit_server/domain/terms/dto/request/EditTermRequest.java
+++ b/src/main/java/welkit_server/domain/terms/dto/request/EditTermRequest.java
@@ -1,6 +1,5 @@
 package welkit_server.domain.terms.dto.request;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
@@ -16,7 +15,6 @@ public class EditTermRequest {
     @Size(min = 1, max = 500)
     private String definition;
 
-    @NotNull
     private Long categoryId;
 
     @Size(min = 1, max = 20)

--- a/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
@@ -16,23 +16,23 @@ public interface TermRepository extends JpaRepository<Term, Long> {
 
     @Query("SELECT t FROM Term t " +
             "WHERE t.user = :user " +
-            "ORDER BY t.createdDate DESC")
+            "ORDER BY t.lastModifiedDate DESC")
     Page<Term> findByUserOrderByCreatedDateDesc(@Param("user") User user, Pageable pageable);
 
     @Query("SELECT t FROM Term t " +
             "WHERE t.user = :user " +
-            "AND t.category.id IN :categoryIds  " +
-            "ORDER BY t.createdDate DESC")
-    Page<Term> findAllByUserAndCategoryIds(
+            "AND t.category.id IN :categoryId  " +
+            "ORDER BY t.lastModifiedDate DESC")
+    Page<Term> findAllByUserAndCategoryId(
             @Param("user") User user,
-            @Param("categoryIds") List<Long>categoryIds,
+            @Param("categoryId") List<Long>categoryId,
             Pageable pageable);
 
     long countByUser(User user);
 
     @Query("SELECT COUNT(t) FROM Term t " +
             "WHERE t.user = :user " +
-            "AND t.category.id IN :categoryIds")
-    long countByUserAndCategoryIds(@Param("user") User user, @Param("categoryIds") List<Long> categoryIds);
+            "AND t.category.id IN :categoryId")
+    long countByUserAndCategoryId(@Param("user") User user, @Param("categoryId") List<Long> categoryIds);
 
 }

--- a/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
@@ -33,6 +33,6 @@ public interface TermRepository extends JpaRepository<Term, Long> {
     @Query("SELECT COUNT(t) FROM Term t " +
             "WHERE t.user = :user " +
             "AND t.category.id IN :categoryId")
-    long countByUserAndCategoryId(@Param("user") User user, @Param("categoryId") List<Long> categoryIds);
+    long countByUserAndCategoryId(@Param("user") User user, @Param("categoryId") List<Long> categoryId);
 
 }

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -20,7 +20,6 @@ import welkit_server.domain.terms.repository.TermRepository;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.repository.UserRepository;
 import welkit_server.global.exception.message.ErrorMessage;
-import welkit_server.global.exception.model.BadRequestException;
 import welkit_server.global.exception.model.ForbiddenException;
 import welkit_server.global.exception.model.NotFoundException;
 import welkit_server.global.exception.model.UnauthorizedException;
@@ -75,7 +74,7 @@ public class TermService {
                 .toList();
 
         if (validCategoryId.isEmpty()) {
-            throw new BadRequestException(ErrorMessage.WK_ENUM_VALUE_BAD_REQUEST);
+            throw new NotFoundException(ErrorMessage.CATEGORY_NOT_FOUND);
         }
         Pageable pageable = PageRequest.of(page,size);
         Page<Term> sortedCategoryTerms =

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -61,21 +61,27 @@ public class TermService {
                 .build();
     }
 
-    public TermsResponse getCategoryTerms( int page, int size, List<Long> categoryIds, Authentication authentication){
+    public TermsResponse getTermsByCategory( int page, int size, List<Long> categoryId, Authentication authentication){
         User user = getAuthenticatedUser(authentication);
 
-        List<Long> validCategoryIds = categoryIds.stream()
+
+        System.out.println("categoryId param: " + categoryId);
+        categoryId.forEach(id -> {
+                    boolean exists = termCategoryRepository.findByIdAndUser(id, user).isPresent();
+                    System.out.println("Checking ID=" + id + ", exists=" + exists);});
+
+        List<Long> validCategoryId = categoryId.stream()
                 .filter(id -> termCategoryRepository.findByIdAndUser(id, user).isPresent())
                 .toList();
 
-        if (validCategoryIds.isEmpty()) {
+        if (validCategoryId.isEmpty()) {
             throw new BadRequestException(ErrorMessage.WK_ENUM_VALUE_BAD_REQUEST);
         }
         Pageable pageable = PageRequest.of(page,size);
         Page<Term> sortedCategoryTerms =
-                termRepository.findAllByUserAndCategoryIds(user, validCategoryIds, pageable);
+                termRepository.findAllByUserAndCategoryId(user, validCategoryId, pageable);
 
-        long categoryCount = termRepository.countByUserAndCategoryIds(user, validCategoryIds);
+        long categoryCount = termRepository.countByUserAndCategoryId(user, validCategoryId);
 
         List<GetAllTermResponse> categorySortedTerms = sortedCategoryTerms.stream()
                 .map(term -> GetAllTermResponse.builder()
@@ -83,6 +89,7 @@ public class TermService {
                         .name(term.getName())
                         .definition(term.getDefinition())
                         .categoryId(term.getCategory().getId())
+                        .updatedAt(term.getLastModifiedDate())
                         .build())
                 .toList();
 
@@ -124,7 +131,7 @@ public class TermService {
 
         term.editTerm(editTermRequest, category);
 
-        return EditTermResponse.    fromEntity(term);
+        return EditTermResponse.fromEntity(term);
     }
 
     @Transactional

--- a/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
+++ b/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
@@ -37,6 +37,7 @@ public enum ErrorMessage {
     TERM_DEFINITION_MAX_LENGTH(400, "TRM1005", "용어 정의는 최대 500자를 초과할 수 없습니다."),
     CATEGORY_NAME_MIN_LENGTH(400, "TRM1006", "카테고리 이름은 최소 1자 이상이어야 합니다."),
     CATEGORY_NAME_MAX_LENGTH(400, "TRM1007", "카테고리 이름은 최대 20자를 초과할 수 없습니다."),
+    CATEGORY_NOT_FOUND(404,"TRM1008","존재하지 않는 카테고리 입니다"),
 
     // 인사이트 카드 (INS)
     INSIGHT_CARD_NOT_FOUND(404, "INS1001", "해당 카드를 찾을 수 없습니다."),


### PR DESCRIPTION
## 🔥 Related Issues
- close #53 

## ✅ 작업 리스트
- [x] 전체/카테고리 조회 기능 분리
- [x] 카테고리 조회 로직 개선
- [x] 용어 조회 기준 수정
- [x] 응답 데이터에 UpdatedAt 추가
- [x] 예외 처리 개선

## 🔧 작업 내용
- 전체 조회와 카테고리 조회를 별도 엔드포인트로 분리
- 카테고리 조회 시 존재하지 않는 카테고리 ID 입력 시 예외 발생하도록 변경 
- 다중 카테고리 선택 가능 -> 하나라도 존재하는 카테고리만 반환
(1/3 카테고리 ID 입력 => 3번 카테고리 없고 1번 카테고리 있음 => 1번  데이터만 보여줌)
- 용어 조회 정렬 기준을 생성일 → 수정일로 변경
- 응답 데이터에 UpdatedAt 필드 추가
- 수정 시 CategoryId 또는 CategoryName 입력 가능
	- 기존 카테고리 선택: CategoryId 사용
	- 새 카테고리 생성 후 수정: CategoryName 전달
- 기존 예외 처리 로직 개선 → 상황별로 세부 예외 처리 적용
## 🤔 궁금한점

## 📸 ScreenShot
