### PR TITLE
fix: 이메일 인증 코드 저장, 검증, 재인증 로직 개선

### DIFF
--- a/src/main/java/welkit_server/domain/auth/signup/company/service/CompanySignupService.java
+++ b/src/main/java/welkit_server/domain/auth/signup/company/service/CompanySignupService.java
@@ -5,6 +5,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.auth.signup.company.dto.SignupRequest;
+import welkit_server.domain.mail.model.EmailCodePurpose;
 import welkit_server.domain.mypage.entity.LockSetting;
 import welkit_server.domain.mypage.model.FeatureName;
 import welkit_server.domain.mypage.repository.LockSettingRepository;
@@ -32,7 +33,7 @@ public class CompanySignupService {
     public void signup(SignupRequest request) {
         String email = request.getEmail();
 
-        if (!redisUtil.isVerifiedEmail(email)) {
+        if (!redisUtil.isVerifiedEmail(email,EmailCodePurpose.SIGN_UP)) {
             throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION);
         }
 
@@ -66,7 +67,7 @@ public class CompanySignupService {
 
         lockSettingRepository.saveAll(lockSettings);
 
-        redisUtil.deleteEmailCode(email);
+        redisUtil.deleteEmailCode(email, EmailCodePurpose.SIGN_UP);
     }
 
     private boolean isBlockedDomain(String email) {

--- a/src/main/java/welkit_server/domain/auth/signup/personal/service/PersonalSignupService.java
+++ b/src/main/java/welkit_server/domain/auth/signup/personal/service/PersonalSignupService.java
@@ -5,6 +5,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.auth.signup.personal.dto.SignupRequest;
+import welkit_server.domain.mail.model.EmailCodePurpose;
 import welkit_server.domain.mypage.entity.LockSetting;
 import welkit_server.domain.mypage.model.FeatureName;
 import welkit_server.domain.mypage.repository.LockSettingRepository;
@@ -30,7 +31,7 @@ public class PersonalSignupService {
     public void signup(SignupRequest request) {
         String email = request.getEmail();
 
-        if (!redisUtil.isVerifiedEmail(email)) {
+        if (!redisUtil.isVerifiedEmail(email,EmailCodePurpose.SIGN_UP)) {
             throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION);
         }
 
@@ -60,6 +61,6 @@ public class PersonalSignupService {
 
         lockSettingRepository.saveAll(lockSettings);
 
-        redisUtil.deleteEmailCode(email);
+        redisUtil.deleteEmailCode(email, EmailCodePurpose.SIGN_UP);
     }
 }

--- a/src/main/java/welkit_server/domain/mail/controller/EmailController.java
+++ b/src/main/java/welkit_server/domain/mail/controller/EmailController.java
@@ -34,7 +34,7 @@ public class EmailController {
     @Operation(summary = "회사 이메일 인증 코드 검증", description = "전송된 인증 코드와 입력값을 비교하여 인증합니다")
     @PutMapping("/company/email")
     public ResponseEntity verifyCompanyEmail(@Valid @RequestBody EmailVerifyRequest emailVerifyRequest) {
-        emailService.verifyEmail(emailVerifyRequest.getEmail(), emailVerifyRequest.getCode(), "회사");
+        emailService.verifyEmail(emailVerifyRequest.getEmail(), emailVerifyRequest.getCode(), EmailCodePurpose.SIGN_UP);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of(SuccessMessage.COMPANY_EMAIL_VERIFICATION_SUCCESS));
@@ -52,7 +52,7 @@ public class EmailController {
     @Operation(summary = "개인 이메일 인증 코드 검증", description = "전송된 인증 코드와 입력값을 비교하여 인증합니다")
     @PutMapping("/personal/email")
     public ResponseEntity verifyPersonalEmail(@Valid @RequestBody EmailVerifyRequest emailVerifyRequest) {
-        emailService.verifyEmail(emailVerifyRequest.getEmail(), emailVerifyRequest.getCode(), "개인");
+        emailService.verifyEmail(emailVerifyRequest.getEmail(), emailVerifyRequest.getCode(), EmailCodePurpose.SIGN_UP);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of(SuccessMessage.PERSONAL_EMAIL_VERIFICATION_SUCCESS));

--- a/src/main/java/welkit_server/domain/mail/controller/EmailController.java
+++ b/src/main/java/welkit_server/domain/mail/controller/EmailController.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import welkit_server.domain.mail.model.EmailCodePurpose;
 import welkit_server.domain.mail.service.EmailService;
 import welkit_server.domain.mail.dto.request.EmailPostRequest;
 import welkit_server.domain.mail.dto.request.EmailVerifyRequest;
@@ -24,7 +25,7 @@ public class EmailController {
     @Operation(summary = "회사 이메일 인증 코드 전송", description = "5분간 유효한 이메일 인증 코드를 전송합니다. ")
     @PostMapping("/company/email")
     public ResponseEntity sendCompanyMail(@Valid @RequestBody EmailPostRequest emailPostRequest) {
-        emailService.sendVerificationEmail(emailPostRequest.getEmail(), "회사");
+        emailService.sendVerificationEmail(emailPostRequest.getEmail(),  EmailCodePurpose.SIGN_UP);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of(SuccessMessage.COMPANY_EMAIL_SEND_SUCCESS, null));
@@ -42,7 +43,7 @@ public class EmailController {
     @Operation(summary = "개인 이메일 인증 코드 전송", description = "5분간 유효한 이메일 인증 코드를 전송합니다.")
     @PostMapping("/personal/email")
     public ResponseEntity sendPersonalMail(@Valid @RequestBody EmailPostRequest emailPostRequest) {
-        emailService.sendVerificationEmail(emailPostRequest.getEmail(), "개인");
+        emailService.sendVerificationEmail(emailPostRequest.getEmail(),EmailCodePurpose.SIGN_UP);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.of(SuccessMessage.PERSONAL_EMAIL_SEND_SUCCESS, null));

--- a/src/main/java/welkit_server/domain/mail/controller/EmailResendController.java
+++ b/src/main/java/welkit_server/domain/mail/controller/EmailResendController.java
@@ -25,8 +25,8 @@ public class EmailResendController {
             @RequestParam EmailCodePurpose purpose,
             @Valid @RequestBody EmailPostRequest emailPostRequest
     ) {
-        String email = emailPostRequest.getEmail();
-        //emailService.resendEmail(email, purpose);
+        emailService.resendEmail(emailPostRequest, purpose);
+
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponse.of(SuccessMessage.EMAIL_SEND_SUCCESS));
     }
@@ -39,7 +39,8 @@ public class EmailResendController {
     ) {
         String email = emailVerifyRequest.getEmail();
         String inputCode = emailVerifyRequest.getCode();
-       // emailService.verifyEmail(email, inputCode, purpose);
+        emailService.verifyEmail(email, inputCode, purpose);
+
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponse.of(SuccessMessage.EMAIL_VERIFICATION_SUCCESS));
     }

--- a/src/main/java/welkit_server/domain/mail/controller/EmailResendController.java
+++ b/src/main/java/welkit_server/domain/mail/controller/EmailResendController.java
@@ -8,29 +8,39 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import welkit_server.domain.mail.dto.request.EmailPostRequest;
 import welkit_server.domain.mail.dto.request.EmailVerifyRequest;
+import welkit_server.domain.mail.model.EmailCodePurpose;
 import welkit_server.domain.mail.service.EmailService;
 import welkit_server.global.dto.SuccessResponse;
 import welkit_server.global.exception.message.SuccessMessage;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/resend")
+@RequestMapping("/auth/email")
 public class EmailResendController {
-
     private final EmailService emailService;
 
-    @Operation(summary = "이메일 인증 코드 재전송", description = "5분간 유효한 이메일 인증 코드를 재전송합니다")
-    @PostMapping("/email")
-    public ResponseEntity resendEmail(@Valid @RequestBody EmailPostRequest emailPostRequest) {
-        emailService.resendEmail(emailPostRequest);
-        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of(SuccessMessage.EMAIL_SEND_SUCCESS));
+    @Operation(summary = "인증 코드 재발송", description = "5분간 유효한 이메일 인증 코드를 재발송합니다")
+    @PostMapping("/resend")
+    public ResponseEntity<SuccessResponse<?>> resendEmail(
+            @RequestParam EmailCodePurpose purpose,
+            @Valid @RequestBody EmailPostRequest emailPostRequest
+    ) {
+        String email = emailPostRequest.getEmail();
+        //emailService.resendEmail(email, purpose);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessMessage.EMAIL_SEND_SUCCESS));
     }
 
-    @Operation(summary = "이메일 인증 재전송 코드 검증", description = "재전송된 인증 코드와 입력값을 비교하여 인증합니다")
-    @PutMapping("/email")
-    public ResponseEntity resendVerifyEmail(@Valid @RequestBody EmailVerifyRequest emailVerifyRequest) {
-        emailService.verifyResendVerificationEmail(emailVerifyRequest);
-        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of(SuccessMessage.EMAIL_VERIFICATION_SUCCESS));
+    @Operation(summary = "재발송된 인증 코드 검증", description = "재전송된 인증 코드와 입력값을 비교하여 인증합니다")
+    @PutMapping("/verify")
+    public ResponseEntity<SuccessResponse<?>> verifyEmail(
+            @RequestParam EmailCodePurpose purpose,
+            @Valid @RequestBody EmailVerifyRequest emailVerifyRequest
+    ) {
+        String email = emailVerifyRequest.getEmail();
+        String inputCode = emailVerifyRequest.getCode();
+       // emailService.verifyEmail(email, inputCode, purpose);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessMessage.EMAIL_VERIFICATION_SUCCESS));
     }
-
 }

--- a/src/main/java/welkit_server/domain/mail/model/EmailCodePurpose.java
+++ b/src/main/java/welkit_server/domain/mail/model/EmailCodePurpose.java
@@ -1,0 +1,7 @@
+package welkit_server.domain.mail.model;
+
+public enum EmailCodePurpose {
+    PASSWORD_RESET,
+    SIGN_UP,
+    CHANGE_EMAIL
+}

--- a/src/main/java/welkit_server/domain/mail/service/EmailService.java
+++ b/src/main/java/welkit_server/domain/mail/service/EmailService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import welkit_server.domain.mail.dto.request.EmailPostRequest;
 import welkit_server.domain.mail.dto.request.EmailVerifyRequest;
 import welkit_server.domain.mail.dto.response.EmailMessageResponse;
+import welkit_server.domain.mail.model.EmailCodePurpose;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.BadRequestException;
 import welkit_server.global.redis.RedisKey;
@@ -26,33 +27,35 @@ public class EmailService {
     private final RedisTemplate<String, String> redisTemplate;
     private final RedisUtil redisUtil;
 
-    public void sendVerificationEmail(String email, String type) {
-        EmailMessageResponse emailMessageResponse = EmailMessageResponse.builder()
-                .to(email)
-                .subject("[welkit] " + type + " 이메일 인증을 위한 인증 코드 발송")
-                .build();
-
-        String code = sendMail(emailMessageResponse, "email");
-        redisUtil.saveEmailCode(email, code);
+    public void sendVerificationEmail(String email, EmailCodePurpose purpose) {
+        String code = createCode();
+        sendMail(email, code, purpose);
+        redisUtil.saveEmailCode(email,code,purpose);
     }
 
-    public String sendMail(EmailMessageResponse emailMessage, String type){
-        String authNum = createCode();
+    private void sendMail(String email, String code, EmailCodePurpose purpose) {
         MimeMessage mimeMessage = mailSender.createMimeMessage();
-        try{
-            if (type.equals("email")) {
-                mimeMessage.setRecipients(Message.RecipientType.TO, emailMessage.getTo());
-                mimeMessage.setSubject(emailMessage.getSubject());
-                mimeMessage.setText("인증번호: " + authNum, "utf-8");
-                mimeMessage.setFrom("no-reply@welkit.kr");
-                mailSender.send(mimeMessage);
-                redisTemplate.opsForValue().set(RedisKey.EMAIL_CODE.getKey(emailMessage.getTo()), authNum, RedisKey.EMAIL_CODE.getTtl() );
-            }
-        }catch (MessagingException e){
-            log.error("메일 전송 실패", e);
+        try {
+            mimeMessage.setRecipients(Message.RecipientType.TO, email);
+            mimeMessage.setSubject("[welkit] " + getSubjectByPurpose(purpose));
+            mimeMessage.setText("인증번호: " + code, "utf-8");
+            mimeMessage.setFrom("no-reply@welkit.kr");
+
+            mailSender.send(mimeMessage);
+            log.info("메일 전송 완료 - email: {}, purpose: {}, code: {}", email, purpose, code);
+
+        } catch (MessagingException e) {
+            log.error("메일 전송 실패 - email: {}", email, e);
             throw new RuntimeException("메일 전송 실패");
         }
-        return authNum;
+    }
+
+    private String getSubjectByPurpose(EmailCodePurpose purpose) {
+        return switch (purpose) {
+            case PASSWORD_RESET -> "비밀번호 재설정을 위한 인증 코드 발송";
+            case SIGN_UP -> "회원가입 이메일 인증 코드 발송";
+            case CHANGE_EMAIL -> "이메일 변경 인증 코드 발송";
+        };
     }
 
     public void verifyEmail(String email, String inputCode, String type) {
@@ -79,17 +82,17 @@ public class EmailService {
         log.info("{} 이메일 인증 성공 - email: {}", type, email);
     }
 
-    public void resendVerificationEmail(String email) {
+    public void resendVerificationEmail(String email,EmailCodePurpose purpose) {
         EmailMessageResponse emailMessageResponse = EmailMessageResponse.builder()
                 .to(email)
                 .subject("[welkit] 이메일 재인증을 위한 인증 코드 발송")
                 .build();
 
-        String code = sendMail(emailMessageResponse, "email");
-        redisUtil.saveEmailCode(email, code);
+        //String code = sendMail(emailMessageResponse, "email",purpose);
+        //redisUtil.saveEmailCode(email, code, purpose);
     }
 
-    public void resendEmail(EmailPostRequest emailPostRequest){
+    public void resendEmail(EmailPostRequest emailPostRequest,EmailCodePurpose purpose) {
 
         String email = emailPostRequest.getEmail();
         String key = RedisKey.EMAIL_CODE.getKey(email);
@@ -98,7 +101,7 @@ public class EmailService {
             redisTemplate.delete(key);
         }
 
-        resendVerificationEmail(email);
+        resendVerificationEmail(email,purpose);
     }
 
     public void verifyResendVerificationEmail(EmailVerifyRequest emailVerifyRequest) {

--- a/src/main/java/welkit_server/domain/mail/service/EmailService.java
+++ b/src/main/java/welkit_server/domain/mail/service/EmailService.java
@@ -74,8 +74,8 @@ public class EmailService {
         }
 
         try {
-            redisUtil.saveVerifiedEmail(email);
-            redisUtil.deleteEmailCode(email);
+            redisUtil.saveVerifiedEmail(email,purpose);
+            redisUtil.deleteEmailCode(email,purpose);
         } catch (Exception e) {
             log.error("이메일 인증 실패 - email: {}", email, e);
             throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION); // 시스템 오류
@@ -84,46 +84,18 @@ public class EmailService {
         log.info("{} 이메일 인증 성공 - email: {}", savedCode, email);
     }
 
-    public void resendVerificationEmail(String email,EmailCodePurpose purpose) {
-        EmailMessageResponse emailMessageResponse = EmailMessageResponse.builder()
-                .to(email)
-                .subject("[welkit] 이메일 재인증을 위한 인증 코드 발송")
-                .build();
-
-        //String code = sendMail(emailMessageResponse, "email",purpose);
-        //redisUtil.saveEmailCode(email, code, purpose);
-    }
-
     public void resendEmail(EmailPostRequest emailPostRequest,EmailCodePurpose purpose) {
 
         String email = emailPostRequest.getEmail();
-        String key = RedisKey.EMAIL_CODE.getKey(email);
+        String key = email + ":" + purpose.name();
 
         if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
             redisTemplate.delete(key);
+            log.info("기존 인증 코드 삭제 완료 - email: {}, purpose: {}", email, purpose);
         }
-
-        resendVerificationEmail(email,purpose);
-    }
-
-    public void verifyResendVerificationEmail(EmailVerifyRequest emailVerifyRequest) {
-        String email = emailVerifyRequest.getEmail();
-        String emailCode = redisUtil.getEmailCode(email);
-        String inputCode = emailVerifyRequest.getCode();
-
-        if (emailCode == null) {
-            throw new BadRequestException(ErrorMessage.EXPIRED_EMAIL_CODE); // 코드 만료
-        }
-
-        if (!emailCode.equals(inputCode.trim())) {
-            throw new BadRequestException(ErrorMessage.INVALID_EMAIL_CODE); // 코드 불일치
-        }
-        try {
-            redisUtil.saveVerifiedEmail(email);
-            redisUtil.deleteEmailCode(email);
-        } catch (Exception e) {
-            throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION); // 시스템 오류
-        }
+        String code = createCode();
+        sendMail(email, code, purpose);
+        redisUtil.saveEmailCode(email,code,purpose);
     }
 
     public String createCode() {

--- a/src/main/java/welkit_server/domain/mail/service/EmailService.java
+++ b/src/main/java/welkit_server/domain/mail/service/EmailService.java
@@ -58,16 +58,18 @@ public class EmailService {
         };
     }
 
-    public void verifyEmail(String email, String inputCode, String type) {
-        String emailCode = redisUtil.getEmailCode(email);
+    public void verifyEmail(String email, String inputCode,EmailCodePurpose purpose) {
 
-        if (emailCode == null) {
-            log.warn("{} 이메일 인증 코드 없음 또는 만료됨 - email: {}", type, email);
+        String key = email + ":" + purpose.name();
+        String savedCode = redisTemplate.opsForValue().get(key);
+
+        if (savedCode== null) {
+            log.warn("{} 이메일 인증 코드 없음 또는 만료됨 - email: {}", purpose, email);
             throw new BadRequestException(ErrorMessage.EXPIRED_EMAIL_CODE); // 코드 만료
         }
 
-        if (!emailCode.equals(inputCode.trim())) {
-            log.warn("{} 이메일 인증 코드 불일치 - email: {}, 입력된 코드: {}", type, email, inputCode);
+        if (!savedCode.equals(inputCode.trim())) {
+            log.warn("{} 이메일 인증 코드 불일치 - email: {}, 입력된 코드: {}", purpose, email, inputCode);
             throw new BadRequestException(ErrorMessage.INVALID_EMAIL_CODE); // 코드 불일치
         }
 
@@ -79,7 +81,7 @@ public class EmailService {
             throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION); // 시스템 오류
         }
 
-        log.info("{} 이메일 인증 성공 - email: {}", type, email);
+        log.info("{} 이메일 인증 성공 - email: {}", savedCode, email);
     }
 
     public void resendVerificationEmail(String email,EmailCodePurpose purpose) {

--- a/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
+++ b/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
@@ -153,7 +153,7 @@ public class MyPageService {
 
         emailService.verifyEmail(email, code, EmailCodePurpose.CHANGE_EMAIL );
 
-        if (!redisUtil.isVerifiedEmail(email)) {
+        if (!redisUtil.isVerifiedEmail(email,EmailCodePurpose.CHANGE_EMAIL)) {
             throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION);
         }
 

--- a/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
+++ b/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
@@ -141,7 +141,7 @@ public class MyPageService {
         String email = emailVerifyRequest.getEmail();
         String code = emailVerifyRequest.getCode();
 
-        emailService.verifyEmail(email, code, "회사" );
+        emailService.verifyEmail(email, code, EmailCodePurpose.CHANGE_EMAIL );
 
         if (!redisUtil.isVerifiedEmail(email)) {
             throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION);

--- a/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
+++ b/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
@@ -126,11 +126,21 @@ public class MyPageService {
 
     public void sendCompanyVerificationEmail(EmailPostRequest emailPostRequest, Authentication authentication) {
         User user = getAuthenticatedUser(authentication);
+        String email = emailPostRequest.getEmail();
 
         if (user.getEmailType() == EmailType.COMPANY_EMAIL) {
             throw new BadRequestException(ErrorMessage.MYP_ALREADY_COMPANY_EMAIL_USER);
         }
-        emailService.sendVerificationEmail(emailPostRequest.getEmail(), EmailCodePurpose.CHANGE_EMAIL);
+
+        if (isBlockedDomain(email)) {
+            throw new BadRequestException(ErrorMessage.MYP_EMAIL_COMPANY_DOMAIN_INVALID);
+        }
+
+        if (userRepository.existsByEmail(email)) {
+            throw new BadRequestException(ErrorMessage.DUPLICATE_EMAIL);
+        }
+
+        emailService.sendVerificationEmail(email, EmailCodePurpose.CHANGE_EMAIL);
     }
 
     @Transactional
@@ -147,13 +157,6 @@ public class MyPageService {
             throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION);
         }
 
-        if (userRepository.existsByEmail(email)) {
-            throw new BadRequestException(ErrorMessage.DUPLICATE_EMAIL);
-        }
-
-        if (isBlockedDomain(email)) {
-            throw new BadRequestException(ErrorMessage.USR_EMAIL_COMPANY_DOMAIN_INVALID);
-        }
         user.setEmailType(EmailType.COMPANY_EMAIL);
     }
 

--- a/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
+++ b/src/main/java/welkit_server/domain/mypage/service/MyPageService.java
@@ -10,6 +10,7 @@ import welkit_server.domain.admin.dto.response.GetAllNoticeResponse;
 import welkit_server.domain.admin.service.NoticeService;
 import welkit_server.domain.mail.dto.request.EmailPostRequest;
 import welkit_server.domain.mail.dto.request.EmailVerifyRequest;
+import welkit_server.domain.mail.model.EmailCodePurpose;
 import welkit_server.domain.mail.service.EmailService;
 import welkit_server.domain.mypage.dto.request.FeatureLockSettingRequest;
 import welkit_server.domain.mypage.dto.request.LockSettingRequest;
@@ -129,7 +130,7 @@ public class MyPageService {
         if (user.getEmailType() == EmailType.COMPANY_EMAIL) {
             throw new BadRequestException(ErrorMessage.MYP_ALREADY_COMPANY_EMAIL_USER);
         }
-        emailService.sendVerificationEmail(emailPostRequest.getEmail(), "회사");
+        emailService.sendVerificationEmail(emailPostRequest.getEmail(), EmailCodePurpose.CHANGE_EMAIL);
     }
 
     @Transactional

--- a/src/main/java/welkit_server/domain/user/service/ResetPasswordService.java
+++ b/src/main/java/welkit_server/domain/user/service/ResetPasswordService.java
@@ -27,19 +27,21 @@ public class ResetPasswordService {
     private final EmailService emailService;
 
     public void sendEmail(EmailPostRequest emailPostRequest) {
-       String email = emailPostRequest.getEmail();
+        String email = emailPostRequest.getEmail();
        emailService.sendVerificationEmail(email, EmailCodePurpose.PASSWORD_RESET);
     }
 
     public void verifyEmail(EmailVerifyRequest emailVerifyRequest) {
-        emailService.verifyResendVerificationEmail(emailVerifyRequest);
+        String email = emailVerifyRequest.getEmail();
+        String inputCode = emailVerifyRequest.getCode();
+        emailService.verifyEmail(email,inputCode,EmailCodePurpose.PASSWORD_RESET);
     }
 
     @Transactional
     public void resetPassword(ResetPasswordRequest resetPasswordRequest) {
         String email = resetPasswordRequest.getEmail();
 
-        if(!redisUtil.isVerifiedEmail(email)) {
+        if(!redisUtil.isVerifiedEmail(email,EmailCodePurpose.PASSWORD_RESET)) {
             throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION);
         }
 

--- a/src/main/java/welkit_server/domain/user/service/ResetPasswordService.java
+++ b/src/main/java/welkit_server/domain/user/service/ResetPasswordService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.mail.dto.request.EmailPostRequest;
 import welkit_server.domain.mail.dto.request.EmailVerifyRequest;
+import welkit_server.domain.mail.model.EmailCodePurpose;
 import welkit_server.domain.mail.service.EmailService;
 import welkit_server.domain.user.dto.request.ResetPasswordRequest;
 import welkit_server.domain.user.entity.User;
@@ -26,7 +27,8 @@ public class ResetPasswordService {
     private final EmailService emailService;
 
     public void sendEmail(EmailPostRequest emailPostRequest) {
-        emailService.resendEmail(emailPostRequest);
+       String email = emailPostRequest.getEmail();
+       emailService.sendVerificationEmail(email, EmailCodePurpose.PASSWORD_RESET);
     }
 
     public void verifyEmail(EmailVerifyRequest emailVerifyRequest) {

--- a/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
+++ b/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
@@ -65,6 +65,7 @@ public enum ErrorMessage {
     MYP_LOCK_PIN_NOT_FOUND(400, "MYP1004", "PIN이 설정되어 있지 않아 잠금 기능을 사용할 수 없습니다"),
     MYP_INVALID_LOCK_PIN(400, "MYP1005","PIN이 올바르지 않습니다."),
     MYP_ALREADY_COMPANY_EMAIL_USER(400, "MYP1006","이미 회사 이메일로 인증된 사용자입니다."),
+    MYP_EMAIL_COMPANY_DOMAIN_INVALID(400,"MYP1007","해당 이메일은 회사 인증이 불가능합니다"),
 
     // 인증/인가 (AUTH)
     SESSION_EXPIRED(401, "AUTH1001", "세션이 만료되었습니다. 다시 로그인해주세요."),

--- a/src/main/java/welkit_server/global/redis/RedisUtil.java
+++ b/src/main/java/welkit_server/global/redis/RedisUtil.java
@@ -5,6 +5,7 @@ import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+import welkit_server.domain.mail.model.EmailCodePurpose;
 
 @Component
 @Slf4j
@@ -18,9 +19,10 @@ public class RedisUtil {
         log.info("RedisUtil 초기화 : RedisTemplate = {}", redisTemplate);
     }
 
-    public void saveEmailCode(String email, String code) {
+    public void saveEmailCode(String email, String code, EmailCodePurpose purpose) {
         log.info("Redis 저장 시도: email = {}, code = {}", email, code);
-        redisTemplate.opsForValue().set(RedisKey.EMAIL_CODE.getKey(email), code, RedisKey.EMAIL_CODE.getTtl());
+        String key = email + ":"  + purpose.name();
+        redisTemplate.opsForValue().set(key, code, RedisKey.EMAIL_CODE.getTtl());
     }
 
     public String getEmailCode(String email) {

--- a/src/main/java/welkit_server/global/redis/RedisUtil.java
+++ b/src/main/java/welkit_server/global/redis/RedisUtil.java
@@ -25,20 +25,19 @@ public class RedisUtil {
         redisTemplate.opsForValue().set(key, code, RedisKey.EMAIL_CODE.getTtl());
     }
 
-    public String getEmailCode(String email) {
-        return redisTemplate.opsForValue().get(RedisKey.EMAIL_CODE.getKey(email));
+    public void deleteEmailCode(String email,EmailCodePurpose purpose) {
+        String key = email + ":"  + purpose.name();
+        redisTemplate.delete(key);
+        log.info("인증 코드 삭제 완료 - email: {}, purpose: {}", email, purpose);    }
+
+    public void saveVerifiedEmail(String email, EmailCodePurpose purpose) {
+        String key = email + ":" + purpose.name() + ":verified";
+        redisTemplate.opsForValue().set(key, "true", RedisKey.VERIFIED_EMAIL.getTtl());
     }
 
-    public void deleteEmailCode(String email) {
-        redisTemplate.delete(RedisKey.EMAIL_CODE.getKey(email));
-    }
-
-    public void saveVerifiedEmail(String email) {
-        redisTemplate.opsForValue().set(RedisKey.VERIFIED_EMAIL.getKey(email), "true" , RedisKey.VERIFIED_EMAIL.getTtl());
-    }
-
-    public boolean isVerifiedEmail(String email) {
-        String result = redisTemplate.opsForValue().get(RedisKey.VERIFIED_EMAIL.getKey(email));
+    public boolean isVerifiedEmail(String email, EmailCodePurpose purpose) {
+        String key = email + ":" + purpose.name() + ":verified";
+        String result = redisTemplate.opsForValue().get(key);
         return "true".equals(result);
     }
 


### PR DESCRIPTION
## 🔥 Related Issues
- close #55 

## 🐞 문제 요약
- 현재 이메일 인증 코드를 목적(Purpose) 별로 구분하지 않고 동일하게 검증하고 있음.
- 그 결과, 예를 들어 회원가입이나 이메일 변경 플로우에서 발급된 인증 코드로도 비밀번호 재설정이 가능해져 보안 취약점이 발생

## 💥 발생 상황
- 사용자가 비밀번호 재설정을 요청하지 않았음에도, 타인이 동일 이메일로 다른 인증 절차(회원가입, 이메일 인증 등)에서 받은 코드로 비밀번호를 재설정할 수 있음.
- 목적 구분이 없어 인증 코드가 서로 덮어쓰임.

## ✅ 작업 리스트
- [x] 이메일 인증 코드 목적(Purpose) 구분 로직 적용
- [x] Redis 저장/조회 시 Purpose 포함
- [x] 인증 코드 검증 시 해당 Purpose만 허용하도록 구현
- [x] 마이페이지 회사 이메일 인증 흐름 관련 버그 수정

## 🔧 작업 내용
- Redis에 인증 코드 저장 시 구조를 변경하여 목적별로 인증 코드 분리 및 저장.
(ex) `emailCode:PASSWORD_RESET:yeong20311@gmail.com`
- 재발송 시 동일 purpose의 기존 코드를 삭제 후 새 코드 발급
- 검증 시 반드시 요청한 purpose 기준으로 Redis에서 코드 조회 후 비교 / purpose 가 다른 경우 예외 처리
- 마이페이지 회사 이메일 인증 흐름 관련 버그 수정
- Purpose 종류 _**(PASSWORD_RESET / SIGN_UP / CHANGE_EMAIL)**_
- 재전송 시 Purpose 전달: 재전송 API 호출 시 purpose 파라미터를 전달하여, 해당 기능(회원가입, 비밀번호 재설정 등)용 인증 코드만 발급/검증 가능
(ex) `POST /auth/email/resend?purpose=SIGN_UP`
