### PR TITLE
용어사전 및 커뮤니티 조회 DTO 필드 추가

### DIFF
--- a/src/main/java/welkit_server/domain/community/controller/CommunityController.java
+++ b/src/main/java/welkit_server/domain/community/controller/CommunityController.java
@@ -14,8 +14,6 @@ import welkit_server.domain.user.model.JobRole;
 import welkit_server.global.dto.SuccessResponse;
 import welkit_server.global.exception.message.SuccessMessage;
 
-import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/community")
@@ -26,20 +24,18 @@ public class CommunityController {
 
     @Operation(summary = "커뮤니티 글 전체 조회", description = "커뮤니티 글을 전체 조회합니다. 카테고리(직무)별로 필터링할 수 있습니다.")
     @GetMapping("/posts")
-    public ResponseEntity<SuccessResponse<Map<String, List<PostSummaryResponse>>>> getAllPosts(
+    public ResponseEntity<SuccessResponse<PostPageResponse>> getAllPosts(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) JobRole category
     ) {
-        List<PostSummaryResponse> posts = communityService.getAllCommunityPosts(category, page, size);
+        PostPageResponse postsPageResponse = communityService.getAllCommunityPosts(category, page, size);
 
-        Map<String, List<PostSummaryResponse>> response = Map.of("posts", posts);
-
-        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, response));
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, postsPageResponse));
     }
 
     @Operation(summary = "커뮤니티 글 상세 조회", description = "커뮤니티 글의 상세 내용을 조회합니다. 글과 함께 해당 글의 댓글도 함께 조회합니다.")
-    @GetMapping("posts/{postId}")
+    @GetMapping("/posts/{postId}")
     public ResponseEntity<SuccessResponse<PostDetailResponse>> getPostDetail(
             @PathVariable Long postId,
             Authentication authentication
@@ -50,37 +46,37 @@ public class CommunityController {
 
     @Operation(summary = "내가 작성한 글 조회", description = "내가 작성한 커뮤니티 글을 조회합니다.")
     @GetMapping("/myposts")
-    public ResponseEntity<SuccessResponse<Page<PostSummaryResponse>>> getMyPosts(
-            @RequestParam int page,
-            @RequestParam int size,
+    public ResponseEntity<SuccessResponse<PostPageResponse>> getMyPosts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) JobRole category,
             Authentication authentication
     ) {
-        List<PostSummaryResponse> response = communityService.getMyPosts(page, size, category, authentication);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, response));
+         PostPageResponse myPosts  = communityService.getMyPosts(page, size, category, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, myPosts));
     }
 
     @Operation(summary = "내가 댓글 단 글 조회", description = "내가 댓글을 단 커뮤니티 글을 조회합니다.")
     @GetMapping("/mycomments")
-    public ResponseEntity<SuccessResponse<Page<PostSummaryResponse>>> getMyCommentedPosts(
-            @RequestParam int page,
-            @RequestParam int size,
+    public ResponseEntity<SuccessResponse<PostPageResponse>> getMyCommentedPosts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) JobRole category,
             Authentication authentication
     ) {
-        List<PostSummaryResponse> response = communityService.getMyCommentedPosts(page, size, category, authentication);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, response));
+        PostPageResponse myCommentedPosts = communityService.getMyCommentedPosts(page, size, category, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, myCommentedPosts));
     }
 
     @Operation(summary = "게시글 검색", description = "키워드로 게시글을 검색합니다.")
     @GetMapping("/posts/search")
-    public ResponseEntity<SuccessResponse<Page<PostSummaryResponse>>> searchPosts(
-            @RequestParam int page,
-            @RequestParam int size,
+    public ResponseEntity<SuccessResponse<PostPageResponse>> searchPosts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) String keyword
     ) {
-        List<PostSummaryResponse> response = communityService.searchPosts(page, size, keyword);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, response));
+        PostPageResponse searchPosts = communityService.searchPosts(page, size, keyword);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, searchPosts));
     }
 
     @Operation(summary = "커뮤니티 글 작성", description = "새로운 커뮤니티 글을 작성합니다.")
@@ -95,7 +91,7 @@ public class CommunityController {
     }
 
     @Operation(summary = "커뮤니티 글 수정", description = "기존 커뮤니티 글을 수정합니다.")
-    @PatchMapping("posts/{postId}")
+    @PatchMapping("/posts/{postId}")
     public ResponseEntity<SuccessResponse<PostUpdateResponse>> updatePost(
             @PathVariable Long postId,
             @Valid @RequestBody PostUpdateRequest request,
@@ -107,7 +103,7 @@ public class CommunityController {
     }
 
     @Operation(summary = "커뮤니티 글 삭제", description = "기존 커뮤니티 글을 삭제합니다.")
-    @DeleteMapping("posts/{postId}")
+    @DeleteMapping("/posts/{postId}")
     public ResponseEntity<SuccessResponse<Void>> deletePost(
             @PathVariable Long postId,
             Authentication authentication

--- a/src/main/java/welkit_server/domain/community/dto/response/PostPageInfoResponse.java
+++ b/src/main/java/welkit_server/domain/community/dto/response/PostPageInfoResponse.java
@@ -1,0 +1,14 @@
+package welkit_server.domain.community.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostPageInfoResponse {
+
+    private Integer totalPages; // 전체 페이지 수
+    private Long totalElements; // 전체 게시글 수
+
+}

--- a/src/main/java/welkit_server/domain/community/dto/response/PostPageResponse.java
+++ b/src/main/java/welkit_server/domain/community/dto/response/PostPageResponse.java
@@ -1,0 +1,17 @@
+package welkit_server.domain.community.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostPageResponse {
+
+    private PostPageInfoResponse postInfo;
+    private List<PostSummaryResponse> posts;
+
+}
+

--- a/src/main/java/welkit_server/domain/community/repository/CommunityPostRepository.java
+++ b/src/main/java/welkit_server/domain/community/repository/CommunityPostRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.repository.query.Param;
 import welkit_server.domain.community.entity.CommunityPosts;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.model.JobRole;
-import java.util.List;
 import java.util.Optional;
 
 public interface CommunityPostRepository extends JpaRepository<CommunityPosts, Long> {
@@ -20,7 +19,7 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPosts, L
     WHERE p.user = :user
       AND (:jobRole IS NULL OR p.jobRole = :jobRole)
 """)
-    List<CommunityPosts> findByUserAndOptionalJobRole(
+    Page<CommunityPosts> findByUserAndOptionalJobRole(
             @Param("user") User user,
             @Param("jobRole") JobRole jobRole,
             Pageable pageable
@@ -30,7 +29,7 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPosts, L
             "JOIN p.comments c " +
             "WHERE c.user = :user " +
             "AND (:jobRole IS NULL OR p.jobRole = :jobRole)")
-    List<CommunityPosts> findDistinctByComments_UserAndOptionalJobRole(
+    Page<CommunityPosts> findDistinctByComments_UserAndOptionalJobRole(
             @Param("user") User user,
             @Param("jobRole") JobRole jobRole,
             Pageable pageable

--- a/src/main/java/welkit_server/domain/community/service/CommunityService.java
+++ b/src/main/java/welkit_server/domain/community/service/CommunityService.java
@@ -38,20 +38,26 @@ public class CommunityService {
     private final CommunityCommentRepository commentRepository;
     private final UserRepository userRepository;
 
-    public List<PostSummaryResponse> getAllCommunityPosts(JobRole jobRole, int page, int size) {
+    public PostPageResponse getAllCommunityPosts(JobRole jobRole, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-
         Page<CommunityPosts> posts;
 
         if (jobRole != null) {
-            posts = postRepository.findAllByJobRole(jobRole, pageable); // 게시글의 jobRole 기준
+            posts = postRepository.findAllByJobRole(jobRole, pageable);
         } else {
             posts = postRepository.findAll(pageable);
         }
 
-        return posts.getContent().stream()
+        List<PostSummaryResponse> postSummaries = posts.getContent().stream()
                 .map(PostSummaryResponse::fromEntity)
                 .toList();
+
+        PostPageInfoResponse pageInfo = getPostsInfo(posts);
+
+        return PostPageResponse.builder()
+                .postInfo(pageInfo)
+                .posts(postSummaries)
+                .build();
     }
 
     @Transactional(readOnly = true)
@@ -67,34 +73,44 @@ public class CommunityService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostSummaryResponse> getMyPosts(int page, int size, JobRole jobRole, Authentication authentication) {
+    public PostPageResponse getMyPosts(int page, int size, JobRole jobRole, Authentication authentication) {
         User currentUser = getAuthenticatedUser(authentication);
 
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
-        List<CommunityPosts> posts = postRepository.findByUserAndOptionalJobRole(currentUser, jobRole, pageable);
+        Page<CommunityPosts> posts = postRepository.findByUserAndOptionalJobRole(currentUser, jobRole, pageable);
 
-        if (jobRole != null && posts.isEmpty()) {
-            return List.of();
-        }
-
-        return posts.stream()
+        List<PostSummaryResponse> myPostSummaries = posts.stream()
                 .map(PostSummaryResponse::fromEntity)
                 .toList();
+
+        PostPageInfoResponse pageInfo = getPostsInfo(posts);
+
+        return PostPageResponse.builder()
+                .postInfo(pageInfo)
+                .posts(myPostSummaries)
+                .build();
     }
 
     @Transactional(readOnly = true)
-    public List<PostSummaryResponse> getMyCommentedPosts(int page, int size, JobRole jobRole, Authentication authentication) {
+    public PostPageResponse getMyCommentedPosts(int page, int size, JobRole jobRole, Authentication authentication) {
         User currentUser = getAuthenticatedUser(authentication);
 
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
-        List<CommunityPosts> posts = postRepository.findDistinctByComments_UserAndOptionalJobRole(currentUser, jobRole, pageable);
+        Page<CommunityPosts> posts = postRepository.findDistinctByComments_UserAndOptionalJobRole(currentUser, jobRole, pageable);
 
-        return posts.stream()
+        List<PostSummaryResponse> myCommentedPosts = posts.stream()
                 .map(PostSummaryResponse::fromEntity)
                 .toList();
+
+        PostPageInfoResponse pageInfo = getPostsInfo(posts);
+
+        return PostPageResponse.builder()
+                .postInfo(pageInfo)
+                .posts(myCommentedPosts)
+                .build();
     }
 
-    public List<PostSummaryResponse> searchPosts(int page, int size, String keyword) {
+    public PostPageResponse searchPosts(int page, int size, String keyword) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
 
         Page<CommunityPosts> posts;
@@ -105,9 +121,16 @@ public class CommunityService {
             posts = postRepository.searchPostsOptionalKeyword(keyword, pageable);
         }
 
-        return posts.stream()
+        List<PostSummaryResponse> searchPosts = posts.stream()
                 .map(PostSummaryResponse::fromEntity)
                 .toList();
+
+        PostPageInfoResponse pageInfo = getPostsInfo(posts);
+
+        return  PostPageResponse.builder()
+                .postInfo(pageInfo)
+                .posts(searchPosts)
+                .build();
     }
 
     @Transactional
@@ -236,6 +259,16 @@ public class CommunityService {
         int notHelpfulCount = feedbackRepository.countByTargetTypeAndTargetIdAndIsHelpful(targetType, targetId, false);
 
         return FeedbackResponse.fromEntity(targetType, targetId, helpfulCount, notHelpfulCount);
+    }
+
+    public PostPageInfoResponse getPostsInfo(Page<CommunityPosts> posts){
+
+        PostPageInfoResponse pageInfo = PostPageInfoResponse.builder()
+                .totalPages(posts.getTotalPages())
+                .totalElements(posts.getTotalElements())
+                .build();
+
+        return pageInfo;
     }
 
     public Long getAuthenticatedUserId(Authentication authentication) {

--- a/src/main/java/welkit_server/domain/mail/service/EmailService.java
+++ b/src/main/java/welkit_server/domain/mail/service/EmailService.java
@@ -9,12 +9,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import welkit_server.domain.mail.dto.request.EmailPostRequest;
-import welkit_server.domain.mail.dto.request.EmailVerifyRequest;
-import welkit_server.domain.mail.dto.response.EmailMessageResponse;
 import welkit_server.domain.mail.model.EmailCodePurpose;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.BadRequestException;
-import welkit_server.global.redis.RedisKey;
 import welkit_server.global.redis.RedisUtil;
 import java.util.Random;
 

--- a/src/main/java/welkit_server/domain/terms/dto/response/GetAllCategoryName.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/GetAllCategoryName.java
@@ -2,14 +2,11 @@ package welkit_server.domain.terms.dto.response;
 
 import lombok.*;
 
-import java.util.List;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class TermsResponse {
-    private Long totalAmount;
-    private List<GetAllCategoryName> categoryNames;
-    private List<GetAllTermResponse> terms;
+public class GetAllCategoryName {
+    private long categoryId;
+    private String categoryName;
 }

--- a/src/main/java/welkit_server/domain/terms/repository/TermCategoryRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermCategoryRepository.java
@@ -1,9 +1,12 @@
 package welkit_server.domain.terms.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import welkit_server.domain.terms.entity.TermCategory;
 import welkit_server.domain.user.entity.User;
+
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +14,6 @@ public interface TermCategoryRepository extends JpaRepository<TermCategory, Long
 
     Optional<TermCategory> findByIdAndUser(Long categoryId, User user);
 
+    @Query("SELECT c FROM TermCategory c WHERE c.user = :user")
+    List<TermCategory> findAlLCategory(User user);
 }

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -9,10 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import welkit_server.domain.terms.dto.request.CreateTermRequest;
 import welkit_server.domain.terms.dto.request.EditTermRequest;
-import welkit_server.domain.terms.dto.response.EditTermResponse;
-import welkit_server.domain.terms.dto.response.CreateTermResponse;
-import welkit_server.domain.terms.dto.response.GetAllTermResponse;
-import welkit_server.domain.terms.dto.response.TermsResponse;
+import welkit_server.domain.terms.dto.response.*;
 import welkit_server.domain.terms.entity.Term;
 import welkit_server.domain.terms.entity.TermCategory;
 import welkit_server.domain.terms.repository.TermCategoryRepository;
@@ -44,6 +41,13 @@ public class TermService {
 
         long totalCount = termRepository.countByUser(user);
 
+        List<GetAllCategoryName> getAllCategoryNames = termCategoryRepository.findAlLCategory(user).stream()
+                .map(termCategory -> GetAllCategoryName.builder()
+                        .categoryId(termCategory.getId())
+                        .categoryName(termCategory.getName())
+                        .build())
+                .toList();
+
         List<GetAllTermResponse> terms =  termList.getContent().stream()
                 .map(term -> GetAllTermResponse.builder()
                         .termId(term.getId())
@@ -56,6 +60,7 @@ public class TermService {
 
         return TermsResponse.builder()
                 .totalAmount(totalCount)
+                .categoryNames(getAllCategoryNames)
                 .terms(terms)
                 .build();
     }

--- a/src/main/java/welkit_server/global/security/config/SecurityConfig.java
+++ b/src/main/java/welkit_server/global/security/config/SecurityConfig.java
@@ -19,7 +19,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import welkit_server.global.security.jwt.JWTFilter;
 import welkit_server.global.security.jwt.JWTUtil;
 import welkit_server.global.security.jwt.LoginFilter;
-
 import java.util.Collections;
 
 @Configuration
@@ -66,9 +65,10 @@ public class SecurityConfig {
                 // 로그인/회원가입 API는 누구나 접근 가능
                 .requestMatchers(
                         "/users/signup/**",
-                        "/resend/**",
                         "/users/login","/users/logout",
                         "/auth/**",
+                        "/privacy/**",
+                        "/agreement/**",
                         "/"
                 ).permitAll()
                 // 관리자 권한이 필요한 경로

--- a/src/main/java/welkit_server/global/security/jwt/JWTFilter.java
+++ b/src/main/java/welkit_server/global/security/jwt/JWTFilter.java
@@ -15,7 +15,6 @@ import welkit_server.domain.user.model.UserType;
 import welkit_server.global.dto.ErrorResponse;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.security.dto.CustomUserDetails;
-
 import java.io.IOException;
 
 @RequiredArgsConstructor
@@ -30,9 +29,8 @@ public class JWTFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getServletPath();
-        return path.startsWith("/users/signup") || path.startsWith("/resend") ||
-                path.startsWith("/auth") || path.equals("/users/login") ||
-                path.equals("/") || path.equals("/users/logout");
+        return path.startsWith("/users/signup") || path.startsWith("/auth") || path.equals("/users/login") ||
+               path.startsWith("/privacy") || path.startsWith("/agreement") ||  path.equals("/") || path.equals("/users/logout");
     }
 
     @Override


### PR DESCRIPTION
## 🔥 Related Issues
- close #62 

## ✅ 작업 리스트
- [x] 용어사전 전체 조회시 카테고리 목록도 반환
- [x] 커뮤니티 조회시 페이지 정보 포함

## 🔧 작업 내용
- 용어사전 전체 조회시 사용자가 등록한 카테고리 목록도  응답데이터에 담아서 반환 
- 커뮤니티 조회(전체, 댓글단 글, 등록한 글, 검색)
응답 데이터에 페이지 정보 (커뮤니티 게시글 수, 총 페이지 수 ) 포함해서 반환

## 🤔 궁금한점

## 📸 ScreenShot
