### PR TITLE
게시글 검색/조회 경로 permitAll 처리 및 FeatureLockInterceptor 예외 경로 설정

### DIFF
--- a/src/main/java/welkit_server/domain/community/service/CommunityService.java
+++ b/src/main/java/welkit_server/domain/community/service/CommunityService.java
@@ -137,6 +137,8 @@ public class CommunityService {
     public PostResponse createPost(PostCreateRequest request, Authentication authentication) {
         User user = getAuthenticatedUser(authentication);
 
+        checkIsCompanyVerified(user);
+
         CommunityPosts post = CommunityPosts.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
@@ -183,6 +185,9 @@ public class CommunityService {
     @Transactional
     public CommentResponse createComment(CommentCreateRequest request, Long postId, Authentication authentication) {
         User user = getAuthenticatedUser(authentication);
+
+        checkIsCompanyVerified(user);
+
         CommunityPosts post = postRepository.findById(postId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.COMMUNITY_POST_NOT_FOUND));
 
@@ -238,6 +243,8 @@ public class CommunityService {
     public FeedbackResponse toggleHelpful(FeedbackRequest request, Authentication authentication) {
         User user = getAuthenticatedUser(authentication);
 
+        checkIsCompanyVerified(user);
+
         Long targetId = request.getTargetId();
         TargetType targetType = request.getTargetType();
         Boolean isHelpful = request.getIsHelpful();
@@ -279,6 +286,12 @@ public class CommunityService {
     public User getAuthenticatedUser(Authentication authentication) {
         return userRepository.findById(getAuthenticatedUserId(authentication))
                 .orElseThrow(() -> new UnauthorizedException(ErrorMessage.SESSION_EXPIRED));
+    }
+
+    private static void checkIsCompanyVerified(User user) {
+        if (!user.isCompanyVerified()) {
+            throw new UnauthorizedException(ErrorMessage.COMMUNITY_COMPANY_NOT_VERIFIED);
+        }
     }
 
 }

--- a/src/main/java/welkit_server/domain/mypage/intercepter/FeatureLockInterceptor.java
+++ b/src/main/java/welkit_server/domain/mypage/intercepter/FeatureLockInterceptor.java
@@ -28,11 +28,8 @@ public class FeatureLockInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         String path = request.getRequestURI();
-        String method = request.getMethod();
-
-        if ((path.equals("/community/posts") || path.equals("/community/posts/search"))
-                && "GET".equalsIgnoreCase(method)) {
-            return true;
+        if (path.equals("/community/posts") || path.equals("/community/posts/search")) {
+            return true; // 인터셉터 제외
         }
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/welkit_server/domain/mypage/intercepter/FeatureLockInterceptor.java
+++ b/src/main/java/welkit_server/domain/mypage/intercepter/FeatureLockInterceptor.java
@@ -27,13 +27,22 @@ public class FeatureLockInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+
+        if ((path.equals("/community/posts") || path.equals("/community/posts/search"))
+                && "GET".equalsIgnoreCase(method)) {
+            return true;
+        }
+
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
+        if (authentication == null || !authentication.isAuthenticated() ||
+                !(authentication.getPrincipal() instanceof CustomUserDetails)) {
             throw new UnauthorizedException(ErrorMessage.SESSION_EXPIRED);
         }
 
         Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
-        FeatureName feature = FeatureName.fromUrl(request.getRequestURI());
+        FeatureName feature = FeatureName.fromUrl(path);
 
         if (feature == null) {
             return true;

--- a/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
+++ b/src/main/java/welkit_server/global/exception/message/ErrorMessage.java
@@ -57,6 +57,7 @@ public enum ErrorMessage {
     // 커뮤니티 (CMN)
     COMMUNITY_POST_NOT_FOUND(404, "CMN1001", "해당 게시글을 찾을 수 없습니다."),
     COMMUNITY_COMMENT_NOT_FOUND(404, "CMN1002", "해당 댓글을 찾을 수 없습니다."),
+    COMMUNITY_COMPANY_NOT_VERIFIED(403, "CMN1003", "회사 인증 후 이용 가능합니다."),
 
     // 마이페이지 (MYP)
     MYP_NOTICE_NOT_FOUND(404, "MYP1001", "해당 공지를 찾을 수 없습니다."),

--- a/src/main/java/welkit_server/global/interceptor/FeatureLockInterceptor.java
+++ b/src/main/java/welkit_server/global/interceptor/FeatureLockInterceptor.java
@@ -1,4 +1,0 @@
-package welkit_server.global.interceptor;
-
-public class FeatureLockInterceptor {
-}

--- a/src/main/java/welkit_server/global/security/config/SecurityConfig.java
+++ b/src/main/java/welkit_server/global/security/config/SecurityConfig.java
@@ -67,6 +67,8 @@ public class SecurityConfig {
                         "/users/signup/**",
                         "/users/login","/users/logout",
                         "/auth/**",
+                        "/community/posts",
+                        "/community/posts/search",
                         "/privacy/**",
                         "/agreement/**",
                         "/"

--- a/src/main/java/welkit_server/global/security/config/SecurityConfig.java
+++ b/src/main/java/welkit_server/global/security/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -62,20 +63,10 @@ public class SecurityConfig {
         http.httpBasic(basic -> basic.disable());
 
         http.authorizeHttpRequests(auth -> auth
-                // 로그인/회원가입 API는 누구나 접근 가능
-                .requestMatchers(
-                        "/users/signup/**",
-                        "/users/login","/users/logout",
-                        "/auth/**",
-                        "/community/posts",
-                        "/community/posts/search",
-                        "/privacy/**",
-                        "/agreement/**",
-                        "/"
-                ).permitAll()
-                // 관리자 권한이 필요한 경로
+                .requestMatchers(HttpMethod.GET, "/community/posts", "/community/posts/search").permitAll()
+                .requestMatchers("/users/signup/**", "/users/login", "/users/logout", "/auth/**",
+                        "/privacy/**", "/agreement/**", "/").permitAll()
                 .requestMatchers("/admin/**").hasRole("ADMIN")
-                // 그 외 모든 요청은 로그인 필요
                 .anyRequest().authenticated()
         );
 

--- a/src/main/java/welkit_server/global/security/jwt/JWTFilter.java
+++ b/src/main/java/welkit_server/global/security/jwt/JWTFilter.java
@@ -30,7 +30,8 @@ public class JWTFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getServletPath();
         return path.startsWith("/users/signup") || path.startsWith("/auth") || path.equals("/users/login") ||
-               path.startsWith("/privacy") || path.startsWith("/agreement") ||  path.equals("/") || path.equals("/users/logout");
+               path.startsWith("/privacy") || path.startsWith("/agreement") ||  path.equals("/") || path.equals("/users/logout") ||
+               path.equals("/community/posts") || path.equals("/community/posts/search");
     }
 
     @Override

--- a/src/main/java/welkit_server/global/security/jwt/JWTFilter.java
+++ b/src/main/java/welkit_server/global/security/jwt/JWTFilter.java
@@ -29,9 +29,23 @@ public class JWTFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getServletPath();
-        return path.startsWith("/users/signup") || path.startsWith("/auth") || path.equals("/users/login") ||
-               path.startsWith("/privacy") || path.startsWith("/agreement") ||  path.equals("/") || path.equals("/users/logout") ||
-               path.equals("/community/posts") || path.equals("/community/posts/search");
+        String method = request.getMethod();
+
+        // GET 요청만 permitAll 처리
+        if (method.equalsIgnoreCase("GET")) {
+            if (path.equals("/community/posts") || path.equals("/community/posts/search")) {
+                return true;
+            }
+        }
+
+        // 기존 permitAll 경로
+        return path.startsWith("/users/signup") ||
+                path.startsWith("/auth") ||
+                path.equals("/users/login") ||
+                path.startsWith("/privacy") ||
+                path.startsWith("/agreement") ||
+                path.equals("/") ||
+                path.equals("/users/logout");
     }
 
     @Override


### PR DESCRIPTION
## 🔥 Related Issues
- close #64

## ✅ 작업 리스트
- [x] 게시글 검색/조회 경로 permitAll 처리
- [x] FeatureLockInterceptor에서 특정 경로 제외

## 🔧 작업 내용
- SecurityConfig, JWTFilter 수정으로 게시글 관련 API 접근 허용
- FeatureLockInterceptor에서 게시글 검색/조회 경로 제외 처리

## 🤔 궁금한점

## 📸 ScreenShot
- 필요시 요청 시 첨부