### PR TITLE
Refresh Token 발급 & 저장

### DIFF
--- a/src/main/java/welkit_server/domain/auth/login/controller/LoginController.java
+++ b/src/main/java/welkit_server/domain/auth/login/controller/LoginController.java
@@ -1,5 +1,6 @@
 package welkit_server.domain.auth.login.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,9 +21,8 @@ public class LoginController {
     private final LoginService loginService;
 
     @PostMapping
-    public ResponseEntity<SuccessResponse> login(@Valid @RequestBody LoginRequest request) {
-        String token = loginService.login(request);
+    public ResponseEntity<SuccessResponse> login(@Valid @RequestBody LoginRequest request, HttpServletResponse response) {
+        String token = loginService.login(request, response);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOGIN_SUCCESS, token));
     }
-
 }

--- a/src/main/java/welkit_server/domain/auth/login/service/LoginService.java
+++ b/src/main/java/welkit_server/domain/auth/login/service/LoginService.java
@@ -1,9 +1,12 @@
 package welkit_server.domain.auth.login.service;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import welkit_server.domain.auth.login.dto.LoginRequest;
+import welkit_server.domain.auth.refresh.service.RefreshTokenService;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.repository.UserRepository;
 import welkit_server.global.exception.message.ErrorMessage;
@@ -17,8 +20,9 @@ public class LoginService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JWTUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
 
-    public String login(LoginRequest request) {
+    public String login(LoginRequest request, HttpServletResponse response) {
         User user = userRepository.findByEmail(request.getEmail())
                 .or(() -> userRepository.findByGoogleEmail(request.getEmail()))
                 .orElseThrow(() -> new BadRequestException(ErrorMessage.INVALID_CREDENTIAL));
@@ -27,12 +31,33 @@ public class LoginService {
             throw new BadRequestException(ErrorMessage.INVALID_CREDENTIAL);
         }
 
-        return jwtUtil.createJwt(
+        // 액세스 토큰 발급
+        String accessToken = jwtUtil.createJwt(
                 user.getLoginEmail(),
                 user.getId(),
                 user.getUserType().name(),
                 user.getJobRole().name(),
                 60 * 60 * 1000L
         );
+
+        // 리프레시 토큰 발급 및 저장
+        String refreshToken = jwtUtil.createJwt(
+                user.getLoginEmail(),
+                user.getId(),
+                user.getUserType().name(),
+                user.getJobRole().name(),
+                7 * 24 * 60 * 60 * 1000L
+        );
+        refreshTokenService.saveRefreshToken(user.getId(), refreshToken, 7 * 24 * 60 * 60 * 1000L);
+
+        // 리프레시 토큰을 쿠키에 저장
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setHttpOnly(true); // JavaScript에서 접근 불가
+        refreshTokenCookie.setSecure(true); // HTTPS에서만 전송 (개발 환경에서는 false)
+        refreshTokenCookie.setPath("/"); // 쿠키의 유효 경로 설정
+        refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60); // 쿠키 만료 시간 설정 (7일)
+        response.addCookie(refreshTokenCookie);
+
+        return accessToken;
     }
 }

--- a/src/main/java/welkit_server/domain/auth/logout/controller/LogoutController.java
+++ b/src/main/java/welkit_server/domain/auth/logout/controller/LogoutController.java
@@ -1,5 +1,7 @@
 package welkit_server.domain.auth.logout.controller;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,8 +22,17 @@ public class LogoutController {
     private final LogoutService logoutService;
 
     @PostMapping
-    public ResponseEntity<SuccessResponse> logout(@Valid @RequestBody LogoutRequest request) {
+    public ResponseEntity<SuccessResponse> logout(@Valid @RequestBody LogoutRequest request, HttpServletResponse response) {
         logoutService.logout(request);
+
+        // 리프레시 토큰 쿠키 삭제
+        Cookie refreshTokenCookie = new Cookie("refreshToken", null);
+        refreshTokenCookie.setHttpOnly(true); // JavaScript에서 접근 불가
+        refreshTokenCookie.setSecure(true); // HTTPS에서만 전송
+        refreshTokenCookie.setPath("/"); // 쿠키의 유효 경로 설정
+        refreshTokenCookie.setMaxAge(0); // 쿠키 즉시 만료
+        response.addCookie(refreshTokenCookie);
+
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOGOUT_SUCCESS));
     }
 }

--- a/src/main/java/welkit_server/domain/auth/logout/service/LogoutService.java
+++ b/src/main/java/welkit_server/domain/auth/logout/service/LogoutService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import welkit_server.domain.auth.logout.dto.LogoutRequest;
+import welkit_server.domain.auth.refresh.service.RefreshTokenService;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.BadRequestException;
 import welkit_server.global.security.jwt.JWTUtil;
@@ -16,6 +17,7 @@ public class LogoutService {
 
     private final JWTUtil jwtUtil;
     private final StringRedisTemplate redisTemplate;
+    private final RefreshTokenService refreshTokenService;
 
     public void logout(LogoutRequest request) {
         String token = request.getToken();
@@ -34,5 +36,9 @@ public class LogoutService {
                 expiration,
                 TimeUnit.MILLISECONDS
         );
+
+        // 리프레시 토큰 삭제
+        Long userId = jwtUtil.getUserId(token);
+        refreshTokenService.deleteRefreshToken(userId);
     }
 }

--- a/src/main/java/welkit_server/domain/auth/refresh/controller/RefreshTokenController.java
+++ b/src/main/java/welkit_server/domain/auth/refresh/controller/RefreshTokenController.java
@@ -1,0 +1,25 @@
+package welkit_server.domain.auth.refresh.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import welkit_server.domain.auth.refresh.service.RefreshTokenService;
+import welkit_server.global.dto.SuccessResponse;
+import welkit_server.global.exception.message.SuccessMessage;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class RefreshTokenController {
+
+    private final RefreshTokenService refreshTokenService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<SuccessResponse> refreshAccessToken(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response) {
+        String newAccessToken = refreshTokenService.refreshAccessToken(refreshToken, response);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.ACCESS_TOKEN_REISSUE_SUCCESS, newAccessToken));
+    }
+}

--- a/src/main/java/welkit_server/domain/auth/refresh/service/RefreshTokenService.java
+++ b/src/main/java/welkit_server/domain/auth/refresh/service/RefreshTokenService.java
@@ -1,0 +1,88 @@
+package welkit_server.domain.auth.refresh.service;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import welkit_server.domain.user.entity.User;
+import welkit_server.domain.user.repository.UserRepository;
+import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.NotFoundException;
+import welkit_server.global.exception.model.UnauthorizedException;
+import welkit_server.global.security.jwt.JWTUtil;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final JWTUtil jwtUtil;
+    private final UserRepository userRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh:";
+
+    // 리프레시 토큰 저장
+    public void saveRefreshToken(Long userId, String refreshToken, long expirationMs) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        redisTemplate.opsForValue().set(key, refreshToken, expirationMs, TimeUnit.MILLISECONDS);
+    }
+
+    // 리프레시 토큰 검증
+    public boolean validateRefreshToken(Long userId, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        String storedToken = redisTemplate.opsForValue().get(key);
+        return refreshToken.equals(storedToken);
+    }
+
+    // 리프레시 토큰 삭제
+    public void deleteRefreshToken(Long userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        redisTemplate.delete(key);
+    }
+
+    public String refreshAccessToken(String refreshToken, HttpServletResponse response) {
+        // 리프레시 토큰 검증
+        if (refreshToken == null || refreshToken.isBlank() || !jwtUtil.validateToken(refreshToken)) {
+            throw new UnauthorizedException(ErrorMessage.INVALID_TOKEN);
+        }
+
+        // 토큰에서 사용자 정보 추출
+        Long userId = jwtUtil.getUserId(refreshToken);
+
+        // 사용자 정보 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND));
+
+        // 새로운 액세스 토큰 및 리프레시 토큰 발급
+        String newAccessToken = jwtUtil.createJwt(
+                user.getLoginEmail(),
+                user.getId(),
+                user.getUserType().name(),
+                user.getJobRole().name(),
+                60 * 60 * 1000L
+        );
+        String newRefreshToken = jwtUtil.createJwt(
+                user.getLoginEmail(),
+                user.getId(),
+                user.getUserType().name(),
+                user.getJobRole().name(),
+                7 * 24 * 60 * 60 * 1000L
+        );
+
+        // 리프레시 토큰 저장 (서버 측)
+        saveRefreshToken(userId, newRefreshToken, 7 * 24 * 60 * 60 * 1000L);
+
+        // 리프레시 토큰을 쿠키에 저장
+        Cookie refreshTokenCookie = new Cookie("refreshToken", newRefreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60);
+        response.addCookie(refreshTokenCookie);
+
+        return newAccessToken;
+    }
+}

--- a/src/main/java/welkit_server/global/exception/message/SuccessMessage.java
+++ b/src/main/java/welkit_server/global/exception/message/SuccessMessage.java
@@ -36,6 +36,7 @@ public enum SuccessMessage {
     COMPANY_EMAIL_REGISTER_SUCCESS(HttpStatus.CREATED.value(), "회사 메일 회원가입이 완료되었습니다."),
     PERSONAL_EMAIL_REGISTER_SUCCESS(HttpStatus.CREATED.value(), "개인 메일 회원가입이 완료되었습니다."),
     GOOGLE_COMPANY_REGISTER_SUCCESS(HttpStatus.CREATED.value(), "구글 로그인을 통한 회사 인증 회원가입이 완료되었습니다."),
+    ACCESS_TOKEN_REISSUE_SUCCESS(HttpStatus.CREATED.value(), "액세스 토큰 재발급이 완료되었습니다."),
 
     /*
     204 No Content


### PR DESCRIPTION
## 🔥 Related Issues
- close #70

## ✅ 작업 리스트
- [x] 로그인 시 Refresh Token 발급 및 HttpOnly 쿠키로 전달
- [x] Redis에 Refresh Token 저장
- [x] 액세스 토큰 재발급(Refresh) 기능 구현
- [x] 로그아웃 시 Access Token 블랙리스트 등록 및 Refresh Token 삭제
- [x] 관련 컨트롤러/서비스/메시지 클래스 수정

## 🔧 작업 내용
- 로그인 성공 시 AccessToken 헤더, RefreshToken 쿠키 발급
- LogoutController/Service 수정: 로그아웃 시 AccessToken 블랙리스트 등록, Refresh Token 삭제
- LoginService 수정: 기존 AccessToken 반환 방식 변경 없이 Redis 연동

## 🤔 궁금한점

## 📸 ScreenShot