### PR TITLE
용어사전 기능 컨트롤러 테스트 코드 작성 

### DIFF
--- a/src/test/java/welkit_server/controller/term/TermControllerTest.java
+++ b/src/test/java/welkit_server/controller/term/TermControllerTest.java
@@ -26,12 +26,16 @@ import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.model.EmailType;
 import welkit_server.domain.user.model.JobRole;
 import welkit_server.domain.user.model.UserType;
+import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.NotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import static java.time.LocalDateTime.now;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -41,7 +45,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class TermControllerTest extends BaseControllerTest {
 
     private static final String DEFAULT_URL = "/terms";
-    private static final String CATEGORY_SEARCH_URL = DEFAULT_URL + "/category";
     private static final String EDIT_DELETE_URL = DEFAULT_URL + "/{id}";
 
     @MockitoBean
@@ -91,8 +94,6 @@ public class TermControllerTest extends BaseControllerTest {
         );
     }
 
-
-
     Authentication authentication = new UsernamePasswordAuthenticationToken(testUser,null,new ArrayList<>());
 
     @Test
@@ -138,7 +139,7 @@ public class TermControllerTest extends BaseControllerTest {
 
     @Test
     @DisplayName("용어 사전 용어 등록 성공 테스트")
-    void createTerm() throws Exception {
+    void createTermSuccess() throws Exception {
         //given
         TermCategory category = termCategory;
 
@@ -168,7 +169,7 @@ public class TermControllerTest extends BaseControllerTest {
 
     @Test
     @DisplayName("용어 사전 용어 수정 성공 테스트")
-    void updateTerm() throws Exception {
+    void updateTermSuccess() throws Exception {
         //given
         EditTermRequest editTermRequest = EditTermRequest.builder()
                 .name("용어2")
@@ -197,6 +198,55 @@ public class TermControllerTest extends BaseControllerTest {
 
     }
 
+    @Test
+    @DisplayName("용어 사전 용어 수정 실패 테스트- 등록되어 있지않는 용어 수정시 예외발생 ")
+    void updateTermFail() throws Exception {
+        //given
+        EditTermRequest editTermRequest = EditTermRequest.builder()
+                .name("용어2")
+                .definition("용어테스트")
+                .categoryId(1L)
+                .build();
+        given(termService.editTerm(eq(2L),any(EditTermRequest.class),any(Authentication.class)))
+                .willThrow(new NotFoundException(ErrorMessage.TERM_NOT_FOUND));
 
+
+        //when
+        ResultActions resultActions = mockMvc.perform(patch(EDIT_DELETE_URL,2L)
+                .principal(authentication)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(editTermRequest)));
+
+        //then
+        resultActions.andExpect(status().isNotFound());
+        resultActions.andExpect(jsonPath("$.message").value(ErrorMessage.TERM_NOT_FOUND.getMessage()));
+
+    }
+
+    @Test
+    @DisplayName("용어 사전 용어 삭제 성공 테스트")
+    void deleteTermSuccess() throws Exception {
+        //given
+        doNothing().when(termService).deleteTerm(eq(1L),any(Authentication.class));
+        //when / then
+        mockMvc.perform(delete(EDIT_DELETE_URL,1L))
+                .andExpect(status().isOk());
+
+    }
+
+    @Test
+    @DisplayName("용어 사전 용어 삭제 실패 테스트 - 존재하지 않는 용어를 삭제할 경우 예외 발생")
+    void deleteTermFail() throws Exception {
+        //given
+        doThrow(new NotFoundException(ErrorMessage.TERM_NOT_FOUND))
+                .when(termService).deleteTerm(eq(2L),any(Authentication.class));
+        //when
+        ResultActions resultActions = mockMvc.perform(delete(EDIT_DELETE_URL, 2L)
+                .principal(authentication)) ;
+        //then
+        resultActions.andExpect(status().isNotFound());
+        resultActions.andExpect(jsonPath("$.message").value(ErrorMessage.TERM_NOT_FOUND.getMessage()));
+
+    }
 
 }

--- a/src/test/java/welkit_server/controller/term/TermControllerTest.java
+++ b/src/test/java/welkit_server/controller/term/TermControllerTest.java
@@ -1,0 +1,132 @@
+package welkit_server.controller.term;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import welkit_server.common.fixture.TermCategoryFixture;
+import welkit_server.common.fixture.TermFixture;
+import welkit_server.controller.BaseControllerTest;
+import welkit_server.domain.mypage.intercepter.FeatureLockInterceptor;
+import welkit_server.domain.terms.controller.TermController;
+import welkit_server.domain.terms.dto.response.GetAllCategoryName;
+import welkit_server.domain.terms.dto.response.GetAllTermResponse;
+import welkit_server.domain.terms.dto.response.TermsResponse;
+import welkit_server.domain.terms.entity.Term;
+import welkit_server.domain.terms.entity.TermCategory;
+import welkit_server.domain.terms.service.TermService;
+import welkit_server.domain.user.entity.User;
+import welkit_server.domain.user.model.EmailType;
+import welkit_server.domain.user.model.JobRole;
+import welkit_server.domain.user.model.UserType;
+import java.util.ArrayList;
+import java.util.List;
+import static java.time.LocalDateTime.now;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("용어사전 컨트롤러 테스트")
+@WebMvcTest(controllers = TermController.class)
+public class TermControllerTest extends BaseControllerTest {
+
+    private static final String DEFAULT_URL = "/terms";
+    private static final String CATEGORY_SEARCH_URL = DEFAULT_URL + "/category";
+    private static final String EDIT_DELETE_URL = DEFAULT_URL + "/{id}";
+
+    @MockitoBean
+    private TermService termService;
+
+    @MockitoBean
+    private FeatureLockInterceptor featureLockInterceptor;
+
+    @BeforeEach
+    void setupInterceptor() {
+        given(featureLockInterceptor.preHandle(any(), any(), any())).willReturn(true);
+    }
+
+    private User testUser;
+    private Term term;
+    private TermCategory termCategory;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .emailType(EmailType.COMPANY_EMAIL)
+                .password("qwer1234!")
+                .isCompanyVerified(true)
+                .jobRole(JobRole.AI_DEVELOP_DATA)
+                .lockPin("1234")
+                .userType(UserType.USER)
+                .build();
+        //given
+        termCategory = TermCategoryFixture.termCategory(
+                1L,
+                "카테고리",
+                testUser
+        );
+        term = TermFixture.term(
+                1L,
+                "용어1",
+                "테스트",
+                termCategory,
+                testUser
+        );
+    }
+
+
+
+    Authentication authentication = new UsernamePasswordAuthenticationToken(testUser,null,new ArrayList<>());
+
+    @Test
+    @DisplayName("용어 조회 성공 테스트")
+    void getAllTerms() throws Exception {
+        //given
+        List<GetAllCategoryName> categoryNames = List.of(
+                GetAllCategoryName.builder()
+                        .categoryId(1L)
+                        .categoryName("카테고리")
+                        .build()
+        );
+
+        List<GetAllTermResponse> terms = List.of(
+                GetAllTermResponse.builder()
+                        .termId(1L)
+                        .name("용어사전테스트")
+                        .definition("용어사전테스트용 단어")
+                        .categoryId(1L)
+                        .updatedAt(now())
+                        .build()
+        );
+
+        TermsResponse termsResponse = TermsResponse.builder()
+                .totalAmount((long) terms.size())
+                .categoryNames(categoryNames)
+                .terms(terms)
+                .build();
+
+        given(termService.getTerms(0, 10, authentication)).willReturn(termsResponse);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get(DEFAULT_URL)
+                .principal(authentication));
+
+        //then
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(jsonPath("$.data.totalAmount").value(terms.size()));
+        resultActions.andExpect(jsonPath("$.data.terms[0].name").value("용어사전테스트"));
+        resultActions.andExpect(jsonPath("$.data.categoryNames[0].categoryName").value("카테고리"));
+    }
+
+
+
+
+}

--- a/src/test/java/welkit_server/controller/term/TermControllerTest.java
+++ b/src/test/java/welkit_server/controller/term/TermControllerTest.java
@@ -3,7 +3,9 @@ package welkit_server.controller.term;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -13,11 +15,12 @@ import welkit_server.common.fixture.TermFixture;
 import welkit_server.controller.BaseControllerTest;
 import welkit_server.domain.mypage.intercepter.FeatureLockInterceptor;
 import welkit_server.domain.terms.controller.TermController;
-import welkit_server.domain.terms.dto.response.GetAllCategoryName;
-import welkit_server.domain.terms.dto.response.GetAllTermResponse;
-import welkit_server.domain.terms.dto.response.TermsResponse;
+import welkit_server.domain.terms.dto.request.CreateTermRequest;
+import welkit_server.domain.terms.dto.request.EditTermRequest;
+import welkit_server.domain.terms.dto.response.*;
 import welkit_server.domain.terms.entity.Term;
 import welkit_server.domain.terms.entity.TermCategory;
+import welkit_server.domain.terms.service.TermCategoryService;
 import welkit_server.domain.terms.service.TermService;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.model.EmailType;
@@ -27,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import static java.time.LocalDateTime.now;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -44,7 +48,12 @@ public class TermControllerTest extends BaseControllerTest {
     private TermService termService;
 
     @MockitoBean
+    private TermCategoryService categoryService;
+
+    @MockitoBean
     private FeatureLockInterceptor featureLockInterceptor;
+    @Autowired
+    private TermCategoryService termCategoryService;
 
     @BeforeEach
     void setupInterceptor() {
@@ -124,8 +133,69 @@ public class TermControllerTest extends BaseControllerTest {
         resultActions.andExpect(jsonPath("$.data.totalAmount").value(terms.size()));
         resultActions.andExpect(jsonPath("$.data.terms[0].name").value("용어사전테스트"));
         resultActions.andExpect(jsonPath("$.data.categoryNames[0].categoryName").value("카테고리"));
+
     }
 
+    @Test
+    @DisplayName("용어 사전 용어 등록 성공 테스트")
+    void createTerm() throws Exception {
+        //given
+        TermCategory category = termCategory;
+
+        CreateTermRequest createTermRequest = CreateTermRequest.builder()
+                .name("용어사전테스트")
+                .definition("용어사전테스트용단어")
+                .categoryId(termCategory.getId())
+                .user(testUser)
+                .build();
+
+        Term term = createTermRequest.toEntity(category,testUser);
+        CreateTermResponse createTermResponse = CreateTermResponse.fromEntity(term);
+
+        given(termService.createTerm(any(CreateTermRequest.class), any(Authentication.class))).willReturn(createTermResponse);
+
+        //when
+        ResultActions resultActions  = mockMvc.perform(post(DEFAULT_URL)
+                .principal(authentication)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createTermRequest)));
+        //then
+        resultActions.andExpect(status().isCreated());
+        resultActions.andExpect(jsonPath("$.data.termId").value(createTermResponse.getTermId()));
+        resultActions.andExpect(jsonPath("$.data.name").value("용어사전테스트"));
+
+    }
+
+    @Test
+    @DisplayName("용어 사전 용어 수정 성공 테스트")
+    void updateTerm() throws Exception {
+        //given
+        EditTermRequest editTermRequest = EditTermRequest.builder()
+                .name("용어2")
+                .definition("용어테스트")
+                .categoryId(1L)
+                .build();
+        EditTermResponse editTermResponse = EditTermResponse.builder()
+                .termId(term.getId())
+                .name(editTermRequest.getName())
+                .definition(editTermRequest.getDefinition())
+                .categoryId(editTermRequest.getCategoryId())
+                .build();
+        given(termService.editTerm(eq(1L),any(EditTermRequest.class),any(Authentication.class))).willReturn(editTermResponse);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(patch(EDIT_DELETE_URL,1L)
+            .principal(authentication)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(editTermRequest)));
+
+        //then
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(jsonPath("$.data.termId").value(editTermResponse.getTermId()));
+        resultActions.andExpect(jsonPath("$.data.name").value("용어2"));
+        resultActions.andExpect(jsonPath("$.data.definition").value("용어테스트"));
+
+    }
 
 
 


### PR DESCRIPTION
## 🔥 Related Issues
- close #79 

## ✅ 작업 리스트
- [x] 용어 등록 / 수정 / 삭제 컨트롤러 테스트
- [x] 용어 사전 조회 로직 컨트롤러 테스트

## 🔧 작업 내용
- 용어 조회 테스트 
   - ` termService.getTerms() `Mock 반환값을 설정하여 카테고리 목록과 용어 목록이 정상적으로 응답
-  용어 등록 테스트 
- 용어 수정 테스트 
   - Mock 결과를 이용해 응답 필드를 검증하였음. 존재하지 않는 용어 수정시 
    NotFoundException 을 발생됨으로써 예외처리도 정상적으로 동작.
- `@WebMvcTest(TermController.class)`로 Controller 단위 테스트 수행.
- FeatureLockInterceptor Mock 설정을 통해 preHandle() 항상 true 반환.
- Authentication 객체를 수동 생성하여 principal로 전달.

## 🤔 궁금한점
- 리뷰어에게 물어보고 싶은 부분이나 애매한 로직 적기

## 📸 ScreenShot
- 필요하다면 캡처 이미지 첨부