### PR TITLE
용어 / 인사이트 카드 / 회고 검색 기능 추가

### DIFF
--- a/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
+++ b/src/main/java/welkit_server/domain/insightcard/controller/InsightCardController.java
@@ -64,6 +64,19 @@ public class InsightCardController {
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, favoritePersonInsightCards));
     }
 
+    @Operation(summary = "인사이트 카드 검색", description = "사용자가 입력한 키워드와 타입에 맞게 인사이트 카드를 검색합니다")
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<GetInsightCardResponse>> searchCards(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) CardType type,
+            Authentication authentication
+    ) {
+        GetInsightCardResponse response = insightCardService.searchCards(page, size, keyword, type, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, response));
+    }
+
 
     @Operation(summary = "인물 카드 생성", description = "새로운 인물 카드를 생성합니다")
     @PostMapping("/person")

--- a/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
+++ b/src/main/java/welkit_server/domain/insightcard/repository/InsightCardRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import welkit_server.domain.insightcard.entity.InsightCard;
 import welkit_server.domain.insightcard.model.CardType;
+import welkit_server.domain.terms.entity.Term;
 import welkit_server.domain.user.entity.User;
 import java.util.List;
 
@@ -36,6 +37,21 @@ public interface InsightCardRepository extends JpaRepository<InsightCard, Long> 
             "ORDER BY i.updatedAt DESC")
     Page<InsightCard> findFavoriteWorkCards(@Param("user") User user, Pageable pageable);
 
+    @Query("""
+           SELECT i FROM InsightCard i
+           WHERE i.user = :user
+           AND (:type IS NULL OR i.type = :type)
+           AND (:keyword IS NULL OR i.title LIKE %:keyword% OR i.description LIKE %:keyword%)
+           ORDER BY i.updatedAt DESC
+    """)
+    Page<InsightCard> searchCards(
+            @Param("user") User user,
+            @Param("type") CardType type,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
     long countByUserAndTypeAndIsFavoriteTrue(User user, CardType type);
     long countByUserAndType(User user, CardType type);
 }
+

--- a/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
+++ b/src/main/java/welkit_server/domain/insightcard/service/InsightCardService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -87,7 +88,7 @@ public class InsightCardService {
     public List<GetAllInsightCardResponse> getTop4LastViewedAtInsightCards(CardType cardType, Authentication authentication) {
         Long userId = userService.getAuthenticatedUserId(authentication);
 
-        List<InsightCard> insightCards = insightCardRepository.findTop4ByUserIdAndTypeAndLastViewedAtIsNotNullOrderByLastViewedAtDesc(userId,cardType);
+        List<InsightCard> insightCards = insightCardRepository.findTop4ByUserIdAndTypeAndLastViewedAtIsNotNullOrderByLastViewedAtDesc(userId, cardType);
 
         return insightCards.stream()
                 .map(insightCard -> GetAllInsightCardResponse.builder()
@@ -101,6 +102,38 @@ public class InsightCardService {
                         .updatedAt(insightCard.getLastModifiedDate())
                         .build())
                 .toList();
+    }
+
+    public GetInsightCardResponse searchCards(
+            int page,
+            int size,
+            String keyword,
+            CardType type,
+            Authentication authentication
+    ) {
+        User user = userService.getAuthenticatedUser(authentication);
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("updatedAt").descending());
+
+        Page<InsightCard> searchResult = insightCardRepository.searchCards(user, type, keyword, pageable);
+
+        List<GetAllInsightCardResponse> cards = searchResult.stream()
+                .map(card -> GetAllInsightCardResponse.builder()
+                        .cardId(card.getId())
+                        .title(card.getTitle())
+                        .description(card.getDescription())
+                        .note(card.getNote())
+                        .type(card.getType())
+                        .favorite(card.isFavorite())
+                        .lastViewedAt(card.getLastViewedAt())
+                        .updatedAt(card.getLastModifiedDate())
+                        .build())
+                .toList();
+
+        return GetInsightCardResponse.builder()
+                .totalAmount(searchResult.getTotalElements())
+                .cards(cards)
+                .build();
     }
 
     @Transactional

--- a/src/main/java/welkit_server/domain/mypage/model/FeatureName.java
+++ b/src/main/java/welkit_server/domain/mypage/model/FeatureName.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 public enum FeatureName {
     INSIGHT_CARDS("/cards"),
     TERMS("/terms"),
-    COMMUNITY("/community"),
     RETROSPECTIVES("/retrospectives");
 
     private final String pathPrefix;

--- a/src/main/java/welkit_server/domain/retrospectives/controller/RetrospectiveController.java
+++ b/src/main/java/welkit_server/domain/retrospectives/controller/RetrospectiveController.java
@@ -48,6 +48,19 @@ public class RetrospectiveController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessResponse.of(SuccessMessage.CREATED_SUCCESS, createRetrospectiveResponse));
     }
+
+    @Operation(summary = "회고 검색", description = "사용자가 입력한 키워드와 타입에 맞게 회고를 검색합니다")
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<GetAllRetrospectiveResponse>> searchRetrospectives(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "4") int size,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Type type,
+            Authentication authentication
+    ) {
+        List<GetAllRetrospectiveResponse> response = retrospectiveService.searchRetrospectives(page, size, keyword, type, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, response));
+    }
     
     @Operation(summary = "회고 수정", description = "등록되어 있는 회고를 수정합니다")
     @PatchMapping("/{id}")

--- a/src/main/java/welkit_server/domain/retrospectives/repository/RetrospectiveRepository.java
+++ b/src/main/java/welkit_server/domain/retrospectives/repository/RetrospectiveRepository.java
@@ -18,5 +18,18 @@ public interface RetrospectiveRepository extends JpaRepository<Retrospective, Lo
             "ORDER BY r.createdDate DESC")
     Page<Retrospective> findAllRetrospectives(@Param("user") User user, @Param("type") Type type, Pageable pageable);
 
+    @Query("""
+           SELECT r FROM Retrospective r
+           WHERE r.user = :user
+           AND (:type IS NULL OR r.type = :type)
+           AND (:keyword IS NULL OR r.title LIKE %:keyword% OR r.content LIKE %:keyword%)
+           ORDER BY r.createdDate DESC
+    """)
+    Page<Retrospective> searchRetrospectives(
+            @Param("user") User user,
+            @Param("type") Type type,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }
 

--- a/src/main/java/welkit_server/domain/retrospectives/service/RetrospectiveService.java
+++ b/src/main/java/welkit_server/domain/retrospectives/service/RetrospectiveService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,6 +52,31 @@ public class RetrospectiveService {
     public RetrospectiveResponse getRetrospectiveById(Long retrospectiveId, Authentication authentication) {
         Long userId = userService.getAuthenticatedUserId(authentication);
         return RetrospectiveResponse.fromEntity(findOwnedRetrospective(userId, retrospectiveId));
+    }
+
+    public List<GetAllRetrospectiveResponse> searchRetrospectives(
+            int page,
+            int size,
+            String keyword,
+            Type type,
+            Authentication authentication
+    ) {
+        User user = userService.getAuthenticatedUser(authentication);
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
+
+        Page<Retrospective> searchResult = retrospectiveRepository.searchRetrospectives(user, type, keyword, pageable);
+
+        return searchResult.getContent().stream()
+                .map(retrospective -> GetAllRetrospectiveResponse.builder()
+                        .retrospectiveId(retrospective.getId())
+                        .title(retrospective.getTitle())
+                        .content(retrospective.getContent())
+                        .type(retrospective.getType())
+                        .startDate(retrospective.getStartDate())
+                        .endDate(retrospective.getEndDate())
+                        .createdAt(retrospective.getCreatedDate())
+                        .build())
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/welkit_server/domain/terms/controller/TermController.java
+++ b/src/main/java/welkit_server/domain/terms/controller/TermController.java
@@ -9,10 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import welkit_server.domain.terms.dto.request.CreateTermRequest;
 import welkit_server.domain.terms.dto.request.EditTermRequest;
-import welkit_server.domain.terms.dto.response.EditTermResponse;
-import welkit_server.domain.terms.dto.response.CreateTermResponse;
-import welkit_server.domain.terms.dto.response.GetAllTermResponse;
-import welkit_server.domain.terms.dto.response.TermsResponse;
+import welkit_server.domain.terms.dto.response.*;
 import welkit_server.domain.terms.service.TermService;
 import welkit_server.global.dto.SuccessResponse;
 import welkit_server.global.exception.message.SuccessMessage;
@@ -46,6 +43,19 @@ public class TermController {
     ) {
         TermsResponse termsFindByCategory = termService.getTermsByCategory(page,size,categoryId, authentication);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, termsFindByCategory));
+    }
+
+    @Operation(summary = "용어 검색", description = "사용자가 입력한 키워드 에 맞게 또는 선택한 카테고리 안에서 입력한 키워드에 맞게 용어를 검색합니다")
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<TermSearchResponse>> searchTerms(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) List<Long> categoryId,
+            Authentication authentication
+     ){
+        TermSearchResponse termSearchResponse = termService.searchTerms(page,size,keyword,categoryId, authentication);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, termSearchResponse));
     }
 
     @Operation(summary = "용어 등록", description = "새로운 용어를 등록합니다")

--- a/src/main/java/welkit_server/domain/terms/dto/response/TermSearchResponse.java
+++ b/src/main/java/welkit_server/domain/terms/dto/response/TermSearchResponse.java
@@ -1,0 +1,12 @@
+package welkit_server.domain.terms.dto.response;
+
+import lombok.*;
+import java.util.List;
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class TermSearchResponse {
+    private Long totalAmount;
+    private List<GetAllTermResponse> terms;
+}

--- a/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
+++ b/src/main/java/welkit_server/domain/terms/repository/TermRepository.java
@@ -28,11 +28,25 @@ public interface TermRepository extends JpaRepository<Term, Long> {
             @Param("categoryId") List<Long>categoryId,
             Pageable pageable);
 
+    @Query("""
+           SELECT t FROM Term t
+           WHERE t.user = :user
+           AND (:keyword IS NULL OR t.name LIKE %:keyword% OR t.definition LIKE %:keyword%)
+           AND(:categoryId IS NULL OR t.category.id IN :categoryId)
+           ORDER BY t.lastModifiedDate DESC
+    """)
+    Page<Term> searchTerms(
+            @Param("user") User user,
+            @Param("keyword") String keyword,
+            @Param("categoryId") List<Long>categoryId,
+            Pageable pageable);
+
     long countByUser(User user);
 
     @Query("SELECT COUNT(t) FROM Term t " +
             "WHERE t.user = :user " +
             "AND t.category.id IN :categoryId")
     long countByUserAndCategoryId(@Param("user") User user, @Param("categoryId") List<Long> categoryId);
+
 
 }

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -102,7 +102,6 @@ public class TermService {
 
     }
 
-    @Transactional
     public TermSearchResponse searchTerms(
             int page,
             int size,

--- a/src/main/java/welkit_server/domain/terms/service/TermService.java
+++ b/src/main/java/welkit_server/domain/terms/service/TermService.java
@@ -103,6 +103,46 @@ public class TermService {
     }
 
     @Transactional
+    public TermSearchResponse searchTerms(
+            int page,
+            int size,
+            String keyword,
+            List<Long> categoryId,
+            Authentication authentication
+    ) {
+        User user = userService.getAuthenticatedUser(authentication);
+
+        List<Long> validCategoryId = null;
+        if (categoryId != null && !categoryId.isEmpty()) {
+            validCategoryId = categoryId.stream()
+                    .filter(id -> termCategoryRepository.findByIdAndUser(id, user).isPresent())
+                    .toList();
+            if (validCategoryId.isEmpty()) {
+                throw new NotFoundException(ErrorMessage.CATEGORY_NOT_FOUND);
+            }
+        }
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<Term> searchTermPage = termRepository.searchTerms(user, keyword, validCategoryId, pageable);
+
+        List<GetAllTermResponse> searchTerms = searchTermPage.stream()
+                .map(term -> GetAllTermResponse.builder()
+                        .termId(term.getId())
+                        .name(term.getName())
+                        .definition(term.getDefinition())
+                        .categoryId(term.getCategory().getId())
+                        .updatedAt(term.getLastModifiedDate())
+                        .build())
+                .toList();
+
+        return TermSearchResponse.builder()
+                .totalAmount(searchTermPage.getTotalElements()) // 전체 검색 결과 수
+                .terms(searchTerms)
+                .build();
+    }
+
+    @Transactional
     public CreateTermResponse createTerm(CreateTermRequest createTermRequest, Authentication authentication) {
         User user = userService.getAuthenticatedUser(authentication);
 


### PR DESCRIPTION
## 🔥 Related Issues
- close #74 
## ✅ 작업 리스트
- [x] 마이페이지 기능 잠금에서 커뮤니티 제외
- [x] 각 기능별 검색 기능 추가 

## 🔧 작업 내용
- 마이페이지 에서 기능 잠금에서 커뮤니티 제외함.
- 용어 검색 기능 추가 
- 회고 / 인사이트 검색 기능 추가 
- 카테고리를 선택 하고 검색을 하거나, 검색만 할 수 있도록 구현

## 🤔 궁금한점
- 리뷰어에게 물어보고 싶은 부분이나 애매한 로직 적기

## 📸 ScreenShot
- 필요하다면 캡처 이미지 첨부