### PR TITLE
커뮤니티 게시글 목록 마크다운 파싱 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'io.lettuce:lettuce-core'
+	implementation 'com.vladsch.flexmark:flexmark-all:0.64.0'
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 	//mail

--- a/src/main/java/welkit_server/domain/community/controller/CommunityController.java
+++ b/src/main/java/welkit_server/domain/community/controller/CommunityController.java
@@ -28,14 +28,14 @@ public class CommunityController {
 
     @Operation(summary = "커뮤니티 글 전체 조회", description = "커뮤니티 글을 전체 조회합니다. 카테고리(직무)별로 필터링할 수 있습니다.")
     @GetMapping("/posts")
-    public ResponseEntity<SuccessResponse<PostPageResponse>> getAllPosts(
+    public ResponseEntity<SuccessResponse<PostPagePlainResponse>> getAllPosts(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) JobRole category
     ) {
-        PostPageResponse postsPageResponse = communityService.getAllCommunityPosts(category, page, size);
+        PostPagePlainResponse postsPagePlainResponse = communityService.getAllCommunityPosts(category, page, size);
 
-        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, postsPageResponse));
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, postsPagePlainResponse));
     }
 
     @Operation(summary = "커뮤니티 글 상세 조회", description = "커뮤니티 글의 상세 내용을 조회합니다. 글과 함께 해당 글의 댓글도 함께 조회합니다.")

--- a/src/main/java/welkit_server/domain/community/dto/response/PostPagePlainResponse.java
+++ b/src/main/java/welkit_server/domain/community/dto/response/PostPagePlainResponse.java
@@ -1,0 +1,17 @@
+package welkit_server.domain.community.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostPagePlainResponse {
+
+    private PostPageInfoResponse postInfo;
+    private List<PostSummaryPlainResponse> posts;
+
+}
+

--- a/src/main/java/welkit_server/domain/community/dto/response/PostSummaryPlainResponse.java
+++ b/src/main/java/welkit_server/domain/community/dto/response/PostSummaryPlainResponse.java
@@ -1,0 +1,53 @@
+package welkit_server.domain.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import welkit_server.domain.community.entity.CommunityPosts;
+import welkit_server.domain.community.model.CommunityPostStatus;
+import welkit_server.domain.user.model.JobRole;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostSummaryPlainResponse {
+
+    private Long postId;
+    private String title;
+    private String content; // 마크다운 파싱 후 순수 텍스트
+    private Long userId;
+    private JobRole jobRole;
+    private CommunityPostStatus status;
+    private int commentCount;
+    private LocalDateTime createdAt;
+    private int helpfulCount;
+    private int notHelpfulCount;
+
+    public static PostSummaryPlainResponse fromEntity(CommunityPosts post, String plainContent) {
+        int commentCount = post.getComments() != null ? post.getComments().size() : 0;
+        int helpfulCount = (int) post.getFeedbacks().stream()
+                .filter(f -> Boolean.TRUE.equals(f.getIsHelpful()))
+                .count();
+        int notHelpfulCount = (int) post.getFeedbacks().stream()
+                .filter(f -> Boolean.FALSE.equals(f.getIsHelpful()))
+                .count();
+
+        return PostSummaryPlainResponse.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .content(plainContent)
+                .userId(post.getUser().getId())
+                .jobRole(post.getJobRole())
+                .status(post.getStatus())
+                .commentCount(commentCount)
+                .createdAt(post.getCreatedDate())
+                .helpfulCount(helpfulCount)
+                .notHelpfulCount(notHelpfulCount)
+                .build();
+    }
+
+}

--- a/src/main/java/welkit_server/domain/community/service/CommunityService.java
+++ b/src/main/java/welkit_server/domain/community/service/CommunityService.java
@@ -24,6 +24,7 @@ import welkit_server.domain.user.service.UserService;
 import welkit_server.global.exception.message.ErrorMessage;
 import welkit_server.global.exception.model.NotFoundException;
 import welkit_server.global.exception.model.UnauthorizedException;
+import welkit_server.util.MarkdownUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +38,8 @@ public class CommunityService {
     private final CommunityCommentRepository commentRepository;
     private final UserService userService;
 
-    public PostPageResponse getAllCommunityPosts(JobRole jobRole, int page, int size) {
+    // CommunityService.java
+    public PostPagePlainResponse getAllCommunityPosts(JobRole jobRole, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdDate"));
         Page<CommunityPosts> posts;
 
@@ -47,13 +49,16 @@ public class CommunityService {
             posts = postRepository.findAll(pageable);
         }
 
-        List<PostSummaryResponse> postSummaries = posts.getContent().stream()
-                .map(PostSummaryResponse::fromEntity)
+        List<PostSummaryPlainResponse> postSummaries = posts.getContent().stream()
+                .map(post -> {
+                    String plainContent = MarkdownUtil.markdownToPlainText(post.getContent());
+                    return PostSummaryPlainResponse.fromEntity(post, plainContent);
+                })
                 .toList();
 
         PostPageInfoResponse pageInfo = getPostsInfo(posts);
 
-        return PostPageResponse.builder()
+        return PostPagePlainResponse.builder()
                 .postInfo(pageInfo)
                 .posts(postSummaries)
                 .build();

--- a/src/main/java/welkit_server/util/MarkdownUtil.java
+++ b/src/main/java/welkit_server/util/MarkdownUtil.java
@@ -1,0 +1,36 @@
+package welkit_server.util;
+
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.ast.Node;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
+
+public final class MarkdownUtil {
+
+    private static final Parser PARSER = Parser.builder().build();
+    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().build();
+
+    private MarkdownUtil() {}
+
+    /** Markdown → HTML */
+    public static String markdownToHtml(String markdown) {
+        if (markdown == null || markdown.isBlank()) return "";
+        Node document = PARSER.parse(markdown);
+        return RENDERER.render(document);
+    }
+
+    /**
+     * Markdown → (HTML) → sanitize → plain text
+     * - Jsoup.clean(..., Safelist.none()) 로 모든 태그 제거 (XSS 방지)
+     * - 이후 Jsoup.parse(...).text() 로 순수 텍스트 추출
+     */
+    public static String markdownToPlainText(String markdown) {
+        String html = markdownToHtml(markdown);
+        // HTML 태그/스크립트 등 모두 제거
+        String cleaned = Jsoup.clean(html, Safelist.none());
+        // 문서에서 텍스트 추출
+        return Jsoup.parse(cleaned).text();
+    }
+
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #87

## ✅ 작업 리스트
- [x] 게시글 목록 조회 시 마크다운 파싱 처리 추가
- [x] HTML 태그 제거 후 순수 텍스트 변환 로직 적용
- [x] 기존 CommunityService 로직에 MarkdownUtil 적용

## 🔧 작업 내용
- 게시글 목록 조회 시 마크다운 문법이 그대로 노출되는 문제 해결  
- 서버에서 마크다운을 HTML로 변환 후, 태그를 제거해 순수 텍스트만 반환하도록 수정  
- 마크다운 변환 및 XSS 방지를 위한 `Jsoup` 기반 정제

## 🤔 궁금한점
- 요약 목록 외에도 게시글 상세 조회 시에도 동일한 파싱 처리를 적용해야 할지 고민 중입니다.  

## 📸 ScreenShot
