### PR TITLE
세션 의존 제거, code를 통한 검증으로 변경

### DIFF
--- a/src/main/java/welkit_server/domain/auth/signup/google/controller/GoogleSignupController.java
+++ b/src/main/java/welkit_server/domain/auth/signup/google/controller/GoogleSignupController.java
@@ -1,8 +1,9 @@
 package welkit_server.domain.auth.signup.google.controller;
 
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import welkit_server.domain.auth.signup.google.dto.GoogleSignupRequest;
@@ -17,22 +18,24 @@ public class GoogleSignupController {
 
     private final GoogleSignupService googleSignupService;
 
-    // 1. 구글 인증 콜백 → 세션에 이메일 저장
     @GetMapping("/callback")
-    public ResponseEntity<Void> googleCallback(@RequestParam("code") String code, HttpSession session) {
-        googleSignupService.saveGoogleEmailToSession(code, session);
-        return ResponseEntity.status(302)
-                .header("Location", "http://localhost:3000/users/signup/google")
+    public ResponseEntity<Void> googleCallback(@RequestParam("code") String code) {
+        // 프론트엔드가 code를 받아 바로 서버에 POST /users/signup/google 로 보낼 예정
+        String redirectUrl = String.format("http://localhost:3000/users/signup/google?code=%s", code);
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header(HttpHeaders.LOCATION, redirectUrl)
                 .build();
     }
 
-    // 2. 구글 인증 후 회원가입
     @PostMapping
     public ResponseEntity<SuccessResponse> signupWithGoogle(
-            @RequestBody @Valid GoogleSignupRequest request,
-            HttpSession session) {
+            @RequestParam("code") String code,
+            @RequestBody @Valid GoogleSignupRequest request) {
 
-        googleSignupService.signupWithSessionEmail(session, request);
+        String email = googleSignupService.getEmailFromCode(code);
+
+        googleSignupService.signup(email, request.getJobRole());
+
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.GOOGLE_COMPANY_REGISTER_SUCCESS, null));
     }
 

--- a/src/main/java/welkit_server/domain/auth/signup/google/service/GoogleSignupService.java
+++ b/src/main/java/welkit_server/domain/auth/signup/google/service/GoogleSignupService.java
@@ -38,27 +38,6 @@ public class GoogleSignupService {
     @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
     private String redirectUri;
 
-    // 세션에 이메일 저장
-    public void saveGoogleEmailToSession(String code, HttpSession session) {
-        String email = getEmailFromCode(code);
-        if (email == null || email.isEmpty()) {
-            throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION);
-        }
-        session.setAttribute("googleEmail", email);
-        System.out.println("Google Email saved in session: " + email);
-    }
-
-    // 회원가입 처리
-    public void signupWithSessionEmail(HttpSession session, GoogleSignupRequest request) {
-        String email = (String) session.getAttribute("googleEmail");
-        if (email == null) {
-            throw new BadRequestException(ErrorMessage.INVALID_EMAIL_VERIFICATION);
-        }
-
-        signup(email, request.getJobRole());
-        session.removeAttribute("googleEmail");
-    }
-
     // 구글 코드로 이메일 가져오기
     public String getEmailFromCode(String code) {
         String tokenUrl = "https://oauth2.googleapis.com/token";

--- a/src/main/java/welkit_server/domain/terms/entity/Term.java
+++ b/src/main/java/welkit_server/domain/terms/entity/Term.java
@@ -25,7 +25,7 @@ public class Term extends BaseEntity {
     private String definition;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", nullable = false)
+    @JoinColumn(name = "category_id")
     private TermCategory category;
 
     @ManyToOne(fetch = FetchType.LAZY,optional = false)

--- a/src/main/java/welkit_server/domain/user/service/UserService.java
+++ b/src/main/java/welkit_server/domain/user/service/UserService.java
@@ -11,6 +11,7 @@ import welkit_server.domain.user.dto.response.UserInfoResponse;
 import welkit_server.domain.user.entity.User;
 import welkit_server.domain.user.repository.UserRepository;
 import welkit_server.global.exception.message.ErrorMessage;
+import welkit_server.global.exception.model.NotFoundException;
 import welkit_server.global.exception.model.UnauthorizedException;
 import welkit_server.global.security.dto.CustomUserDetails;
 import welkit_server.global.security.jwt.JWTUtil;
@@ -25,7 +26,9 @@ public class UserService {
     private final JWTUtil jwtUtil;
 
     public void deleteUser(User user) {
-        userRepository.deleteById(user.getId());
+        userRepository.findById(user.getId())
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND));
+        userRepository.delete(user);
 
         String token = getTokenFromRequest();
         if (token != null) {


### PR DESCRIPTION
## 🔥 Related Issues
- close #issue_number

## ✅ 작업 리스트
- [x] Google Signup 세션 의존 제거, code 검증 방식 적용
- [x] Term 엔티티 categoryId nullable 처리
- [x] User 삭제 시 에러 처리 보완

## 🔧 작업 내용
- categoryId 필드 nullable=true로 변경
- User 삭제 로직에서 발생할 수 있는 예외 처리 보완
- Google OAuth 회원가입 로직에서 세션 의존 제거하고, code 기반 검증으로 변경

## 🤔 궁금한점

## 📸 ScreenShot
- 필요 시 관련 화면 캡처 첨부